### PR TITLE
Add menu

### DIFF
--- a/app/controllers/menu_controller.rb
+++ b/app/controllers/menu_controller.rb
@@ -3,5 +3,6 @@ class MenuController < ApplicationController
   end
 
   def new
+    @menu = Menu.new
   end
 end

--- a/app/controllers/menu_controller.rb
+++ b/app/controllers/menu_controller.rb
@@ -5,4 +5,15 @@ class MenuController < ApplicationController
   def new
     @menu = Menu.new
   end
+
+  def create
+    @menu = Menu.create(menu_params)
+    flash[:notice] = "Successfully added menu"
+    redirect_to menu_index_path(@menu)
+  end
+
+  private
+  def menu_params
+    params.require(:menu).permit(:title)
+  end
 end

--- a/app/controllers/menu_controller.rb
+++ b/app/controllers/menu_controller.rb
@@ -1,4 +1,7 @@
 class MenuController < ApplicationController
   def index
   end
+
+  def new
+  end
 end

--- a/app/controllers/menu_controller.rb
+++ b/app/controllers/menu_controller.rb
@@ -3,11 +3,17 @@ class MenuController < ApplicationController
   end
 
   def new
-    @menu = Menu.new
+    @menu = Menu.new()
   end
 
   def create
-    @menu = menu.create(menu_params)
+    @menu = Menu.create(menu_params)
     flash[:notice] = "Successfully added menu"
+    redirect_to menu_index_path(@menu)
+  end
+
+  private
+  def menu_params
+    params.require(:menu).permit(:title)
   end
 end

--- a/app/controllers/menu_controller.rb
+++ b/app/controllers/menu_controller.rb
@@ -5,4 +5,9 @@ class MenuController < ApplicationController
   def new
     @menu = Menu.new
   end
+
+  def create
+    @menu = menu.create(menu_params)
+    flash[:notice] = "Successfully added menu"
+  end
 end

--- a/app/controllers/menu_controller.rb
+++ b/app/controllers/menu_controller.rb
@@ -16,15 +16,4 @@ class MenuController < ApplicationController
   def menu_params
     params.require(:menu).permit(:title)
   end
-
-  def create
-    @menu = Menu.create(menu_params)
-    flash[:notice] = "Successfully added menu"
-    redirect_to menu_index_path(@menu)
-  end
-
-  private
-  def menu_params
-    params.require(:menu).permit(:title)
-  end
 end

--- a/app/controllers/menu_controller.rb
+++ b/app/controllers/menu_controller.rb
@@ -3,7 +3,7 @@ class MenuController < ApplicationController
   end
 
   def new
-    @menu = Menu.new()
+    @menu = Menu.new
   end
 
   def create

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,0 +1,2 @@
+class Menu < ApplicationRecord
+end

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -1,2 +1,3 @@
 class Menu < ApplicationRecord
+   validates_presence_of :title
 end

--- a/app/views/menu/index.html.haml
+++ b/app/views/menu/index.html.haml
@@ -1,3 +1,6 @@
+- flash.each do |key, value|
+  %div{class: "alert alert-#{key}"}
+    = value
 .row
   .column-md-12
     %h1 Menu for X

--- a/app/views/menu/new.html.haml
+++ b/app/views/menu/new.html.haml
@@ -1,3 +1,4 @@
 .row
   .column-md-12
     %h1 add menu
+    

--- a/app/views/menu/new.html.haml
+++ b/app/views/menu/new.html.haml
@@ -4,5 +4,5 @@
 
     = form_for @menu, url: {action: 'create'}, html: {class: 'add_menu'} do |f|
       = f.label :title do
-        = f.text_field :title
+        = f.text_field :title, id: 'title'
       = f.submit 'Create', id: 'create'

--- a/app/views/menu/new.html.haml
+++ b/app/views/menu/new.html.haml
@@ -3,5 +3,6 @@
     %h1 add menu
 
     = form_for @menu, url: {action: 'create'}, html: {class: 'add_menu'} do |f|
-      = f.text_field :title
+      = f.label :title do
+        = f.text_field :title, id: 'title'
       = f.submit 'Create', id: 'create'

--- a/app/views/menu/new.html.haml
+++ b/app/views/menu/new.html.haml
@@ -3,5 +3,6 @@
     %h1 add menu
 
     = form_for @menu, url: {action: 'create'}, html: {class: 'add_menu'} do |f|
-      = f.text_field :title
+      = f.label :title do
+        = f.text_field :title
       = f.submit 'Create', id: 'create'

--- a/app/views/menu/new.html.haml
+++ b/app/views/menu/new.html.haml
@@ -1,4 +1,7 @@
 .row
   .column-md-12
     %h1 add menu
-    
+
+    = form_for @menu, url: {action: "create"}, html: {class: "add_menu"} do |f|
+      = f.text_field :title
+      = f.submit "Create"

--- a/app/views/menu/new.html.haml
+++ b/app/views/menu/new.html.haml
@@ -2,6 +2,6 @@
   .column-md-12
     %h1 add menu
 
-    = form_for @menu, url: {action: "create"}, html: {class: "add_menu"} do |f|
+    = form_for @menu, url: {action: 'create'}, html: {class: 'add_menu'} do |f|
       = f.text_field :title
-      = f.submit "Create"
+      = f.submit 'Create', id: 'create'

--- a/app/views/menu/new.html.haml
+++ b/app/views/menu/new.html.haml
@@ -1,0 +1,3 @@
+.row
+  .column-md-12
+    %h1 add menu

--- a/app/views/restaurant/index.html.haml
+++ b/app/views/restaurant/index.html.haml
@@ -7,7 +7,7 @@
     %div Restaurant info
     %div Map
     %div
-      = link_to 'Link to menus', menu_path
+      = link_to 'Link to menus', menu_index_path
     %div Highlighted dishes
     %div Comment and rate
     %div

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
   get '/restaurant', controller: :restaurant, action: :index
-  get '/menu', controller: :menu, action: :index
-
+  resources :menu, only: [:index, :create, :new]
 end

--- a/db/migrate/20160928141407_create_menus.rb
+++ b/db/migrate/20160928141407_create_menus.rb
@@ -1,0 +1,8 @@
+class CreateMenus < ActiveRecord::Migration[5.0]
+  def change
+    create_table :menus do |t|
+      t.string  :title, null: false, default: ""
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20160928141407) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "menus", force: :cascade do |t|
+    t.string   "title",      default: "", null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,14 +1,19 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20160928141407) do
 
+  # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-
-  create_table "menus", force: :cascade do |t|
-    t.string   "title",      default: "", null: false
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-  end
 
   create_table "dishes", force: :cascade do |t|
     t.string   "dish_name"
@@ -20,4 +25,11 @@ ActiveRecord::Schema.define(version: 20160928141407) do
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
   end
+
+  create_table "menus", force: :cascade do |t|
+    t.string   "title",      default: "", null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
+
 end

--- a/features/add_menu.feature
+++ b/features/add_menu.feature
@@ -1,0 +1,9 @@
+Feature: As a restaurant Owner
+  in order to sell food
+  I need to be able to add one or more menus.
+
+Scenario: Viewing the Add Menu page
+  Given I am on the "add menu" page
+  Then I should see:
+    | content    |
+    | add menu   |

--- a/features/add_menu.feature
+++ b/features/add_menu.feature
@@ -7,4 +7,4 @@ Scenario: Viewing the Add Menu page
   Then I should see:
     | content    |
     | add menu   |
-  And "create" button
+  And I should see "create" button

--- a/features/add_menu.feature
+++ b/features/add_menu.feature
@@ -8,3 +8,9 @@ Scenario: Viewing the Add Menu page
     | content    |
     | add menu   |
   And I should see "create" button
+
+Scenario: Adding a menu
+  Given I am on the "add menu" page
+  When I fill in "title" with "Awesome Menu"
+  And I click the "create" button
+  Then I should see "Successfully added menu"

--- a/features/add_menu.feature
+++ b/features/add_menu.feature
@@ -7,3 +7,4 @@ Scenario: Viewing the Add Menu page
   Then I should see:
     | content    |
     | add menu   |
+  And "create" button

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -19,6 +19,10 @@ Then(/^I should be on the "([^"]*)" page$/) do |page|
   expect(current_path).to eq expected_page
 end
 
+Then(/^"([^"]*)" button$/) do |button|
+  expect(page).to have_button button
+end
+
 def goto(page)
   case page
   when 'restaurant'

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -25,6 +25,8 @@ def goto(page)
     restaurant_path
   when 'menu'
     menu_path
+  when 'add menu'
+    new_menu_path
   else
     root_path
   end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -19,7 +19,7 @@ Then(/^I should be on the "([^"]*)" page$/) do |page|
   expect(current_path).to eq expected_page
 end
 
-Then(/^"([^"]*)" button$/) do |button|
+Then(/^I should see "([^"]*)" button$/) do |button|
   expect(page).to have_button button
 end
 

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -22,7 +22,17 @@ end
 Then(/^I should see "([^"]*)" button$/) do |button|
   expect(page).to have_button button
 end
+When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |element, text|
+  fill_in element, with: text
+end
 
+When(/^I click the "([^"]*)" button$/) do |button|
+  click_button(button)
+end
+
+Then(/^I should see "([^"]*)"$/) do |message|
+  expect(page).to have_content(message)
+end
 def goto(page)
   case page
   when 'restaurant'

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -31,28 +31,22 @@ When(/^I click the link "([^"]*)"$/) do |link|
   click_link(link)
 end
 
-private
-
 Then(/^I should see "([^"]*)" button$/) do |button|
   expect(page).to have_button button
 end
+
 When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |element, text|
   fill_in element, with: text
 end
 
-When(/^I click the "([^"]*)" button$/) do |button|
-  click_button(button)
-end
+private
 
-Then(/^I should see "([^"]*)"$/) do |message|
-  expect(page).to have_content(message)
-end
 def goto(page)
   case page
   when 'restaurant'
     restaurant_path
   when 'menu'
-    menu_path
+    menu_index_path
   when 'add menu'
     new_menu_path
   when 'Create Dish'

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -22,7 +22,17 @@ end
 Then(/^I should see "([^"]*)" button$/) do |button|
   expect(page).to have_button button
 end
+When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |element, text|
+  fill_in element with: text
+end
 
+When(/^I click the "([^"]*)" button$/) do |button|
+  click_button(button)
+end
+
+Then(/^I should see "([^"]*)"$/) do |message|
+  expect(page).to have_content(message)
+end
 def goto(page)
   case page
   when 'restaurant'

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -23,7 +23,7 @@ Then(/^I should see "([^"]*)" button$/) do |button|
   expect(page).to have_button button
 end
 When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |element, text|
-  fill_in element with: text
+  fill_in element, with: text
 end
 
 When(/^I click the "([^"]*)" button$/) do |button|

--- a/spec/factories/menus.rb
+++ b/spec/factories/menus.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :menu do
+    
+  end
+end

--- a/spec/factories/menus.rb
+++ b/spec/factories/menus.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :menu do
-    
+    title "Awesome title"
   end
 end

--- a/spec/factories/menus.rb
+++ b/spec/factories/menus.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :menu do
-    
+    title "title"
   end
 end

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Menu, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Menu, type: :model do
-  it { is_expected.to have_db_column :title }
+
+  describe "regression test" do
+    it { is_expected.to have_db_column :title }
+
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of :title }    
+  end
 end

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Menu, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { is_expected.to have_db_column :title }
 end

--- a/spec/models/menu_spec.rb
+++ b/spec/models/menu_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Menu, type: :model do
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of :title }    
+    it { is_expected.to validate_presence_of :title }
+  end
+
+  describe 'Factory' do
+    it 'should have valid Factory' do
+      expect(FactoryGirl.create(:menu)).to be_valid
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,4 @@
-\ENV['RAILS_ENV'] ||= 'test'
+ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'


### PR DESCRIPTION
PT Story: 
https://www.pivotaltracker.com/story/show/131070327

Changes proposed in this pull request:
- Menus can be added with title 
- Route for creating menu

To keep the PR size down we split add dishes to menu into another feature. 
(https://www.pivotaltracker.com/story/show/131350845)

What I have learned working on this feature: 
- Given/visit steps needs no expect-line
- Pair programming (ping pong) is efficient and fun (you told us, but now it's experienced)
- Basic steps are composed with ease and no longer with hesitation
- Controllers are named in plural

Screenshots: 
<img width="296" alt="skarmavbild 2016-09-29 kl 10 54 33" src="https://cloud.githubusercontent.com/assets/7266909/18947410/4b8ab67c-8633-11e6-9e2f-b3ecf1b199bc.png">

Ready for review!
