### PR TITLE
Display menu details on menu page

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -10,7 +10,7 @@ class MenusController < ApplicationController
     @menu = Menu.new(menu_params)
     if @menu.save
       flash[:notice] = "Successfully added menu"
-      render :index
+      render :show
     else
       flash[:alert] = @menu.errors.full_messages.first
       render :new

--- a/app/views/menus/show.html.haml
+++ b/app/views/menus/show.html.haml
@@ -1,0 +1,2 @@
+Here's the menu page for
+= @menu.title

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'registrations' }
   get '/restaurant', controller: :restaurants, action: :index
 
-  resources :menus, only: [:index, :create, :new]
+  resources :menus, only: [:index, :create, :new, :show]
   resources :dishes, only: [:new, :show, :create]
 
   root to: 'restaurant#index'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160929083816) do
+ActiveRecord::Schema.define(version: 20160930104627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,13 @@ ActiveRecord::Schema.define(version: 20160929083816) do
     t.text     "dish_ingredients"
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
+  end
+
+  create_table "dishes_menus", id: false, force: :cascade do |t|
+    t.integer "dish_id"
+    t.integer "menu_id"
+    t.index ["dish_id"], name: "index_dishes_menus_on_dish_id", using: :btree
+    t.index ["menu_id"], name: "index_dishes_menus_on_menu_id", using: :btree
   end
 
   create_table "menus", force: :cascade do |t|

--- a/features/add_menu.feature
+++ b/features/add_menu.feature
@@ -17,7 +17,8 @@ Scenario: Adding a menu
 
 Scenario: Viewing my menu
   Given I create a menu "Lunch"
-  Then I should be on the "menu" page for "Lunch"
+  Then I should see "Successfully added menu"
+  Then I should see "Lunch"
 
 Scenario: Not adding a menu
   Given I am on the "add menu" page

--- a/features/add_menu.feature
+++ b/features/add_menu.feature
@@ -15,6 +15,10 @@ Scenario: Adding a menu
   And I click the "create" button
   Then I should see "Successfully added menu"
 
+Scenario: Viewing my menu
+  Given I create a menu "Lunch"
+  Then I should be on the "menu" page for "Lunch"
+
 Scenario: Not adding a menu
   Given I am on the "add menu" page
   When I fill in:

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -1,0 +1,12 @@
+Given(/^I create a menu "([^"]*)"$/) do |menu_name|
+  steps %Q{
+    Given I am on the "add menu" page
+    When I fill in "title" with "#{menu_name}"
+    And I click the "create" button
+  }
+end
+
+Then(/^I should be on the "([^"]*)" page for "([^"]*)"$/) do |page, title|
+  menu_id = Menu.find_by(title: title)
+  expect(current_path).to eq menu_path(menu_id)
+end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/131070515
- Changes proposed in this pull request:
- Display menu details on menu page

What I have learned working on this feature: Neither of these work: `render @menu`, `redirect_to @menu`

Screenshots:
![screen shot 2016-09-30 at 3 25 02 pm](https://cloud.githubusercontent.com/assets/20141428/18993145/189b68ac-8722-11e6-9331-f53aa949d988.png)

Ready for review!
