### PR TITLE
Edit menu and add dishes to it

### DIFF
--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -6,6 +6,10 @@ class MenusController < ApplicationController
     @menu = Menu.new
   end
 
+  def show
+    @menu = Menu.find(params[:id])
+  end
+
   def create
     @menu = Menu.new(menu_params)
     if @menu.save

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -1,4 +1,6 @@
 class MenusController < ApplicationController
+  before_action :find_menu_from_params, only: [:show, :edit, :update]
+
   def index
   end
 
@@ -7,7 +9,6 @@ class MenusController < ApplicationController
   end
 
   def show
-    @menu = Menu.find(params[:id])
   end
 
   def create
@@ -22,23 +23,20 @@ class MenusController < ApplicationController
   end
 
   def edit
-    @menu = Menu.find(params[:id])
     @dishes = Dish.all #this needs to be restricted to only dishes created by the restaurant later on
   end
 
   def update
-    @menu = Menu.find(params[:id])
     @menu.update(menu_params)
-    # params[:menu][:dish_ids].each do |dish|
-    #   @menu.dish_ids << dish
-    #   @menu.save
-    # end
-    # binding.pry
     render :show
   end
 
   private
   def menu_params
     params.require(:menu).permit(:title, {dish_ids: []})
+  end
+
+  def find_menu_from_params
+    @menu = Menu.find(params[:id])
   end
 end

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -17,6 +17,10 @@ class MenusController < ApplicationController
     end
   end
 
+  def edit
+    @menu = Menu.find(params[:id])
+  end
+
   private
   def menu_params
     params.require(:menu).permit(:title)

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -19,6 +19,7 @@ class MenusController < ApplicationController
 
   def edit
     @menu = Menu.find(params[:id])
+    @dishes = @menu.dishes
   end
 
   private

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -24,6 +24,6 @@ class MenusController < ApplicationController
 
   private
   def menu_params
-    params.require(:menu).permit(:title)
+    params.require(:menu).permit(:title, {menu_ids: []})
   end
 end

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -19,7 +19,7 @@ class MenusController < ApplicationController
 
   def edit
     @menu = Menu.find(params[:id])
-    @dishes = @menu.dishes
+    @dishes = Dish.all #this needs to be restricted to only dishes created by the restaurant later on
   end
 
   private

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -22,6 +22,14 @@ class MenusController < ApplicationController
     @dishes = Dish.all #this needs to be restricted to only dishes created by the restaurant later on
   end
 
+  def update
+    @menu = Menu.find(params[:id])
+    params[:menu][:dish_ids].each do |dish|
+      @menu.dish_ids << dish
+    end
+    render :show
+  end
+
   private
   def menu_params
     params.require(:menu).permit(:title, {menu_ids: []})

--- a/app/controllers/menus_controller.rb
+++ b/app/controllers/menus_controller.rb
@@ -24,14 +24,17 @@ class MenusController < ApplicationController
 
   def update
     @menu = Menu.find(params[:id])
-    params[:menu][:dish_ids].each do |dish|
-      @menu.dish_ids << dish
-    end
+    @menu.update(menu_params)
+    # params[:menu][:dish_ids].each do |dish|
+    #   @menu.dish_ids << dish
+    #   @menu.save
+    # end
+    # binding.pry
     render :show
   end
 
   private
   def menu_params
-    params.require(:menu).permit(:title, {menu_ids: []})
+    params.require(:menu).permit(:title, {dish_ids: []})
   end
 end

--- a/app/views/menus/edit.html.haml
+++ b/app/views/menus/edit.html.haml
@@ -6,7 +6,6 @@
       %br/
       = f.text_field :title, id: 'title'
       %br/
-      %h2 Add dishes to menu:
       - if !@menu.dishes.nil?
         %h3 Check to add dishes to menu:
         = f.collection_check_boxes :dish_ids, @dishes, :id, :dish_name do |b|

--- a/app/views/menus/edit.html.haml
+++ b/app/views/menus/edit.html.haml
@@ -3,13 +3,13 @@
     %h1 Edit menu: #{@menu.title}
     = form_for @menu, action: :update do |f|
       = f.label :title, 'Edit Title'
-      %br
+      %br/
       = f.text_field :title, id: 'title'
-      %br
+      %br/
       %h2 Add dishes to menu:
       - if !@menu.dishes.nil?
         %h3 Check to add dishes to menu:
-        = form.collection_check_boxes :dish_ids, @dishes, :id, :dish_name do |b|
+        = f.collection_check_boxes :dish_ids, @dishes, :id, :dish_name do |b|
           .checkbox
             = b.check_box + b.label
       = f.submit 'Update', id: 'create'

--- a/app/views/menus/edit.html.haml
+++ b/app/views/menus/edit.html.haml
@@ -6,4 +6,10 @@
       %br
       = f.text_field :title, id: 'title'
       %br
+      %h2 Add dishes to menu:
+      - if !@menu.dishes.nil?
+        %h3 Check to add dishes to menu:
+        = form.collection_check_boxes :dish_ids, @dishes, :id, :title do |b|
+          .checkbox
+            = b.check_box + b.label
       = f.submit 'Update', id: 'create'

--- a/app/views/menus/edit.html.haml
+++ b/app/views/menus/edit.html.haml
@@ -1,0 +1,9 @@
+.row
+  .column-md-12
+    %h1 Edit menu: #{@menu.title}
+    = form_for @menu, action: :update do |f|
+      = f.label :title, 'Edit Title'
+      %br
+      = f.text_field :title, id: 'title'
+      %br
+      = f.submit 'Update', id: 'create'

--- a/app/views/menus/edit.html.haml
+++ b/app/views/menus/edit.html.haml
@@ -9,7 +9,7 @@
       %h2 Add dishes to menu:
       - if !@menu.dishes.nil?
         %h3 Check to add dishes to menu:
-        = form.collection_check_boxes :dish_ids, @dishes, :id, :title do |b|
+        = form.collection_check_boxes :dish_ids, @dishes, :id, :dish_name do |b|
           .checkbox
             = b.check_box + b.label
       = f.submit 'Update', id: 'create'

--- a/app/views/menus/show.html.haml
+++ b/app/views/menus/show.html.haml
@@ -4,6 +4,5 @@
   Dishes:
   %br/
   - @menu.dishes.each do |dish|
-    #{dish.dish_name},
-    = dish.dish_price
+    = link_to dish.dish_name, dish
     %br/

--- a/app/views/menus/show.html.haml
+++ b/app/views/menus/show.html.haml
@@ -1,2 +1,9 @@
-Here's the menu page for
-= @menu.title
+%h1 Here's the menu page for #{@menu.title}
+%br/
+- if !@menu.dishes.nil?
+  Dishes:
+  %br/
+  - @menu.dishes.each do |dish|
+    #{dish.dish_name},
+    = dish.dish_price
+    %br/

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: { registrations: 'registrations' }
 
-  resources :menus, only: [:index, :create, :new, :show]
+  resources :menus, only: [:index, :create, :new, :show, :edit]
 
   root to: 'restaurants#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: { registrations: 'registrations' }
 
-  resources :menus, only: [:index, :create, :new, :show, :edit]
+  resources :menus, only: [:index, :create, :new, :show, :edit, :update]
 
   root to: 'restaurants#index'
 end

--- a/features/edit_menu.feature
+++ b/features/edit_menu.feature
@@ -17,3 +17,7 @@ Scenario: I edit my menu
     | Add dishes |
     | Pizza      |
     | Salad      |
+  When I check the "Pizza" box
+  And I click the "Update" button
+  Then I should be on the menu page for "Lunch"
+  And I should see "Pizza"

--- a/features/edit_menu.feature
+++ b/features/edit_menu.feature
@@ -7,6 +7,7 @@ Scenario: I edit my menu
     | dish_name | dish_desc       | dish_price |
     | Pizza     | Delicious pizza | 7000       |
     | Salad     | Leafy           | 1500       |
+    | Olives    | Salty           | 900        |
   And the following menus exist:
     | title |
     | Lunch |
@@ -17,7 +18,10 @@ Scenario: I edit my menu
     | Add dishes |
     | Pizza      |
     | Salad      |
+    | Olives     |
   When I check the "Pizza" box
+  And I check the "Olives" box
   And I click the "Update" button
   Then I should be on the menu page for "Lunch"
   And I should see "Pizza"
+  And I should not see "Salad"

--- a/features/edit_menu.feature
+++ b/features/edit_menu.feature
@@ -11,5 +11,9 @@ Scenario: I edit my menu
     | title |
     | Lunch |
   And I am on the edit menu page for "Lunch"
-  Then I should see "Title"
-  And I should see "Dishes"
+  Then I should see:
+    | content    |
+    | Title      |
+    | Add dishes |
+    | Pizza      |
+    | Salad      |

--- a/features/edit_menu.feature
+++ b/features/edit_menu.feature
@@ -2,7 +2,7 @@ Feature: As a restaurant Owner
   in order to sell food
   I need to be able to add one or more dishes to my menus.
 
-Scenario: I edit my menu
+Background:
   Given the following dishes exist
     | dish_name | dish_desc       | dish_price |
     | Pizza     | Delicious pizza | 7000       |
@@ -11,14 +11,9 @@ Scenario: I edit my menu
   And the following menus exist:
     | title |
     | Lunch |
-  And I am on the edit menu page for "Lunch"
-  Then I should see:
-    | content    |
-    | Title      |
-    | add dishes |
-    | Pizza      |
-    | Salad      |
-    | Olives     |
+
+Scenario: I edit my menu
+  Given I am on the edit menu page for "Lunch"
   When I check the "Pizza" box
   And I check the "Olives" box
   And I click the "Update" button

--- a/features/edit_menu.feature
+++ b/features/edit_menu.feature
@@ -15,7 +15,7 @@ Scenario: I edit my menu
   Then I should see:
     | content    |
     | Title      |
-    | Add dishes |
+    | add dishes |
     | Pizza      |
     | Salad      |
     | Olives     |

--- a/features/edit_menu.feature
+++ b/features/edit_menu.feature
@@ -1,0 +1,12 @@
+Feature: As a restaurant Owner
+  in order to sell food
+  I need to be able to add one or more dishes to my menus.
+
+Scenario: I edit my menu
+  Given the following dishes exist
+    | dish_name | dish_desc       | dish_price |
+    | Pizza     | Delicious pizza | 7000       |
+    | Salad     | Leafy           | 1500       |
+  And I am on the "edit menu" page
+  Then I should see "Title"
+  And I should see "Dishes"

--- a/features/edit_menu.feature
+++ b/features/edit_menu.feature
@@ -7,6 +7,9 @@ Scenario: I edit my menu
     | dish_name | dish_desc       | dish_price |
     | Pizza     | Delicious pizza | 7000       |
     | Salad     | Leafy           | 1500       |
-  And I am on the "edit menu" page
+  And the following menus exist:
+    | title |
+    | Lunch |
+  And I am on the edit menu page for "Lunch"
   Then I should see "Title"
   And I should see "Dishes"

--- a/features/menu_page.feature
+++ b/features/menu_page.feature
@@ -11,7 +11,7 @@ Background:
   And the following menus exist:
     | title |
     | Lunch |
-  And I add a dish to the "Lunch" menu
+  And I add "Pizza" to the "Lunch" menu
 
 Scenario: I view the menu
   Given I am on the menu page for "Lunch"

--- a/features/menu_page.feature
+++ b/features/menu_page.feature
@@ -2,14 +2,18 @@ Feature: As a restaurant Owner
   in order to show more menu details
   I need to have a Menu page for each Menu.
 
-Scenario: Viewing the Menu page
-  Given I am on the "menu" page
-  Then I should see:
-    | content    |
-    | Menu for X |
-    | Dish 1     |
+Background:
+  Given the following dishes exist
+    | dish_name | dish_desc       | dish_price |
+    | Pizza     | Delicious pizza | 7000       |
+    | Salad     | Leafy           | 1500       |
+    | Olives    | Salty           | 900        |
+  And the following menus exist:
+    | title |
+    | Lunch |
+  And I add a dish to the "Lunch" menu
 
-Scenario: Browsing to the Menu page
-  Given I am on the "restaurant" page
-  When I click the link "Link to menus"
-  Then I should be on the "menu" page
+Scenario: I view the menu
+  Given I am on the menu page for "Lunch"
+  When I click the link "Pizza"
+  Then I should be on the dish page for "Pizza"

--- a/features/step_definitions/cart_steps.rb
+++ b/features/step_definitions/cart_steps.rb
@@ -1,4 +1,4 @@
-Given(/^the following dish exist$/) do |table|
+Given(/^the following (?:dish|dishes) exist$/) do |table|
   table.hashes.each do |hash|
     FactoryGirl.create(:dish, hash)
   end

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -6,7 +6,7 @@ Given(/^I create a menu "([^"]*)"$/) do |menu_name|
   }
 end
 
-Then(/^I should be on the "([^"]*)" page for "([^"]*)"$/) do |page, title|
+Then(/^I should be on the menu page for "([^"]*)"$/) do |title|
   menu_id = Menu.find_by(title: title)
   expect(current_path).to eq menu_path(menu_id)
 end

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -22,11 +22,11 @@ Given(/^I am on the edit menu page for "([^"]*)"$/) do |menu_name|
   visit edit_menu_path(@menu)
 end
 
-Given(/^I add a dish to the "([^"]*)" menu$/) do |menu|
+Given(/^I add "([^"]*)" to the "([^"]*)" menu$/) do |dish, menu|
   menu_page = Menu.find_by(title: menu)
   visit(edit_menu_path(menu_page))
   steps %Q{
-    When I check the "Pizza" box
+    When I check the "#{dish}" box
     And I click the "Update" button
   }
 end

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -16,3 +16,8 @@ Given(/^the following menus exist:$/) do |table|
     FactoryGirl.create(:menu, title: menu[:title])
   end
 end
+
+Given(/^I am on the edit menu page for "([^"]*)"$/) do |menu_name|
+  @menu = Menu.find_by(title: menu_name)
+  visit edit_menu_path(@menu)
+end

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -21,3 +21,17 @@ Given(/^I am on the edit menu page for "([^"]*)"$/) do |menu_name|
   @menu = Menu.find_by(title: menu_name)
   visit edit_menu_path(@menu)
 end
+
+Given(/^I add a dish to the "([^"]*)" menu$/) do |menu|
+  menu_page = Menu.find_by(title: menu)
+  visit(edit_menu_path(menu_page))
+  steps %Q{
+    When I check the "Pizza" box
+    And I click the "Update" button
+  }
+end
+
+Given(/^I am on the menu page for "([^"]*)"$/) do |menu_name|
+  menu_page = Menu.find_by(title: menu_name)
+  visit(menu_path(menu_page))
+end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/131350845

Changes proposed in this pull request:
- Create edit menu page and functionality
- Add dishes to edit menu page
- Display dishes on menu page
- Dishes on menu page are links to their dish page
- Delete contents of previous menu_page.feature because they test something we don't actually want to happen in our app (displaying a static `/menu` - we will only have `/menu/:id` )

What I have learned working on this feature:
- Better knowledge about how basic Rails routing and info shuffling works

Screenshots:
![screen shot 2016-10-02 at 9 25 37 pm](https://cloud.githubusercontent.com/assets/20141428/19023137/d52be9d6-88e6-11e6-8654-4b46d2322398.png)
![screen shot 2016-10-02 at 9 25 51 pm](https://cloud.githubusercontent.com/assets/20141428/19023138/d8d3f5ce-88e6-11e6-84fc-e3fcc588602e.png)

Ready for review!
