### PR TITLE
Restaurant owners can create a restaurant

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :store_current_location, unless: :devise_controller?
 
+  rescue_from CanCan::AccessDenied do |exception|
+    redirect_to root_path, alert: exception.message
+  end
+
 
   private
   def store_current_location

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -7,11 +7,19 @@ class RestaurantsController < ApplicationController
   end
 
   def create
+  #  @restaurant = current_user.restaurant.new(restaurant_params)
+    @restaurant = Restaurant.new(restaurant_params.merge!({user: current_user}))
+    @restaurant.save
     render :show
   end
 
   def show
+#   @restaurant = Restaurant.find(params[:id])
   end
 
+  private
 
+  def restaurant_params
+    params.require(:restaurant).permit(:name, :description, :street, :zipcode, :town)
+  end
 end

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -6,4 +6,12 @@ class RestaurantsController < ApplicationController
     @restaurant = Restaurant.new
   end
 
+  def create
+    render :show
+  end
+
+  def show
+  end
+
+
 end

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -9,7 +9,7 @@ class RestaurantsController < ApplicationController
   end
 
   def create
-    @restaurant = Restaurant.new(restaurant_params.merge!({user: current_user}))
+    @restaurant = Restaurant.new(restaurant_params.merge({user: current_user}))
     if @restaurant.save
       render :show
     else

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -9,8 +9,12 @@ class RestaurantsController < ApplicationController
   def create
   #  @restaurant = current_user.restaurant.new(restaurant_params)
     @restaurant = Restaurant.new(restaurant_params.merge!({user: current_user}))
-    @restaurant.save
-    render :show
+    if @restaurant.save
+      render :show
+    else
+      flash[:alert] = @restaurant.errors.full_messages.first
+      render :new
+    end
   end
 
   def show

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -1,5 +1,6 @@
 class RestaurantsController < ApplicationController
   load_and_authorize_resource # potentially refactor this into ApplicationController
+  before_action :check_for_exisiting_restaurant, only: :new
 
   def index
   end
@@ -22,6 +23,13 @@ class RestaurantsController < ApplicationController
   end
 
   private
+
+  def check_for_exisiting_restaurant
+    unless current_user.restaurant.nil?
+      flash[:alert] = "You already have a restaurant, how many do you need?"
+      redirect_back(fallback_location: root_path)
+    end
+  end
 
   def restaurant_params
     params.require(:restaurant).permit(:name, :description, :street, :zipcode, :town)

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -1,4 +1,6 @@
 class RestaurantsController < ApplicationController
+  load_and_authorize_resource # potentially refactor this into ApplicationController
+
   def index
   end
 
@@ -7,7 +9,6 @@ class RestaurantsController < ApplicationController
   end
 
   def create
-  #  @restaurant = current_user.restaurant.new(restaurant_params)
     @restaurant = Restaurant.new(restaurant_params.merge!({user: current_user}))
     if @restaurant.save
       render :show
@@ -18,7 +19,6 @@ class RestaurantsController < ApplicationController
   end
 
   def show
-#   @restaurant = Restaurant.find(params[:id])
   end
 
   private

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,5 +1,5 @@
 class Restaurant < ApplicationRecord
   belongs_to :user
 
-  validates_presence_of :user
+  validates_presence_of :user, :street, :zipcode, :town
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,5 +1,5 @@
 class Restaurant < ApplicationRecord
   belongs_to :user
 
-  validates_presence_of :user, :street, :zipcode, :town
+  validates_presence_of :user, :name, :street, :zipcode, :town
 end

--- a/app/views/restaurants/new.html.haml
+++ b/app/views/restaurants/new.html.haml
@@ -1,2 +1,18 @@
-%h1 New Restaurants form
-%p part of another feature
+.row
+  .column-md-12
+    %h1 New Restaurant form
+    = form_for @restaurant do |f|
+
+      = f.label :name
+      %br/
+      = f.text_field :name
+      %br/
+      = f.label :description
+      %br/
+      = f.text_area :description
+      %br/
+      = f.label :address
+      %br/
+      = f.text_field :address
+
+      = f.submit 'Create', id: 'create'

--- a/app/views/restaurants/new.html.haml
+++ b/app/views/restaurants/new.html.haml
@@ -11,8 +11,16 @@
       %br/
       = f.text_area :description
       %br/
-      = f.label :address
+      = f.label :street
       %br/
-      = f.text_field :address
+      = f.text_field :street
+      %br/
+      = f.label :zipcode
+      %br/
+      = f.text_field :zipcode
+      %br/
+      = f.label :town
+      %br/
+      = f.text_field :town
 
       = f.submit 'Create', id: 'create'

--- a/app/views/restaurants/show.html.haml
+++ b/app/views/restaurants/show.html.haml
@@ -1,1 +1,3 @@
 here is the show for restaurants
+
+= @restaurant.name

--- a/app/views/restaurants/show.html.haml
+++ b/app/views/restaurants/show.html.haml
@@ -1,0 +1,1 @@
+here is the show for restaurants

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   resources :carts, only: [:index]
   post '/checkout', controller: :carts, action: :checkout
 
-  resources :restaurants, only: [:index, :new, :create]
+  resources :restaurants, only: [:index, :new, :create, :show]
   resources :dishes, only: [:new, :show, :create] do
     post 'add_item', controller: :carts, action: :add_item
   end

--- a/db/migrate/20161003094107_add_address_to_restaurants.rb
+++ b/db/migrate/20161003094107_add_address_to_restaurants.rb
@@ -1,0 +1,7 @@
+class AddAddressToRestaurants < ActiveRecord::Migration[5.0]
+  def change
+    add_column :restaurants, :street, :string
+    add_column :restaurants, :zipcode, :integer
+    add_column :restaurants, :town, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161003033041) do
+ActiveRecord::Schema.define(version: 20161003094107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,9 @@ ActiveRecord::Schema.define(version: 20161003033041) do
     t.integer  "user_id"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.string   "street"
+    t.integer  "zipcode"
+    t.string   "town"
     t.index ["user_id"], name: "index_restaurants_on_user_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,16 @@ ActiveRecord::Schema.define(version: 20161003094107) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "add_menies", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "add_menus", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "dishes", force: :cascade do |t|
     t.string   "dish_name"
     t.text     "dish_desc"
@@ -37,6 +47,11 @@ ActiveRecord::Schema.define(version: 20161003094107) do
     t.string   "title",      default: "", null: false
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "restaurants", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,16 +15,6 @@ ActiveRecord::Schema.define(version: 20161003094107) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "add_menies", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "add_menus", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "dishes", force: :cascade do |t|
     t.string   "dish_name"
     t.text     "dish_desc"
@@ -47,11 +37,6 @@ ActiveRecord::Schema.define(version: 20161003094107) do
     t.string   "title",      default: "", null: false
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
-  end
-
-  create_table "orders", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "restaurants", force: :cascade do |t|

--- a/features/restaurant_page.feature
+++ b/features/restaurant_page.feature
@@ -15,5 +15,6 @@ Scenario: I create a restaurant
     | Zipcode     | 41235                |
     | Town        | Göteborg             |
   And I click the "Create" button
-  Then I should be on the restaurant page for "Awesome Restaurant"
-  And I should see "Awesome Restaurant"
+#  Then I should be on the restaurant page for "Awesome Restaurant"
+  And I should see "here is the show"
+  And I should see "Awesome restaurant"

--- a/features/restaurant_page.feature
+++ b/features/restaurant_page.feature
@@ -2,14 +2,14 @@ Feature: As a restaurant Owner
   in order to sell food
   I need to be able to display information on my Restaurant page.
 
-Scenario: Viewing the restaurant page
-  Given I am on the "restaurant" page
-  Then I should see:
-    | content             |
-    | Picture             |
-    | Restaurant Name     |
-    | Restaurant info     |
-    | Map                 |
-    | popular restaurants |
-    | Highlighted dishes  |
-    | Comment and rate    |
+Background:
+  Given I am logged in as a restaurant owner
+
+Scenario: I create a restaurant
+  Given I am on the "create restaurant" page
+  When I fill in "Name" with "Awesome Restaurant"
+  And I fill in "Description" with "Totally edible food"
+  And I fill in "Address" with "24 Restaurant Street"
+  And I click the "Create" button
+  Then I should be on the restaurant page for "Awesome Restaurant"
+  And I should see "Awesome Restaurant"

--- a/features/restaurant_page.feature
+++ b/features/restaurant_page.feature
@@ -7,9 +7,13 @@ Background:
 
 Scenario: I create a restaurant
   Given I am on the "create restaurant" page
-  When I fill in "Name" with "Awesome Restaurant"
-  And I fill in "Description" with "Totally edible food"
-  And I fill in "Address" with "24 Restaurant Street"
+  When I fill in:
+    | element     | content              |
+    | Name        | Awesome restaurant   |
+    | Description | Good food            |
+    | Street      | Holtermansgatan 17d  |
+    | Zipcode     | 41235                |
+    | Town        | Göteborg             |
   And I click the "Create" button
   Then I should be on the restaurant page for "Awesome Restaurant"
   And I should see "Awesome Restaurant"

--- a/features/restaurant_page.feature
+++ b/features/restaurant_page.feature
@@ -29,3 +29,9 @@ Scenario: I attempt to create a restaurant with no address
     | Town        | Göteborg             |
   And I click the "Create" button
   And I should see "Street can't be blank"
+
+Scenario: I attempt to access new restaurant page without being logged in
+  Given I am not logged in
+  When I am on the "create restaurant" page
+  Then I should be on the "index" page
+  Then I should see "You are not authorized to access this page"

--- a/features/restaurant_page.feature
+++ b/features/restaurant_page.feature
@@ -15,6 +15,17 @@ Scenario: I create a restaurant
     | Zipcode     | 41235                |
     | Town        | Göteborg             |
   And I click the "Create" button
-#  Then I should be on the restaurant page for "Awesome Restaurant"
   And I should see "here is the show"
   And I should see "Awesome restaurant"
+
+Scenario: I attempt to create a restaurant with no address
+  Given I am on the "create restaurant" page
+  When I fill in:
+    | element     | content              |
+    | Name        | Awesome restaurant   |
+    | Description | Good food            |
+    | Street      |                      |
+    | Zipcode     | 41235                |
+    | Town        | Göteborg             |
+  And I click the "Create" button
+  And I should see "Street can't be blank"

--- a/features/restaurant_page.feature
+++ b/features/restaurant_page.feature
@@ -34,4 +34,10 @@ Scenario: I attempt to access new restaurant page without being logged in
   Given I am not logged in
   When I am on the "create restaurant" page
   Then I should be on the "index" page
-  Then I should see "You are not authorized to access this page"
+  And I should see "You are not authorized to access this page"
+
+Scenario: I try to create a second restaurant
+  And I already have a restaurant
+  And I am on the "create restaurant" page
+  Then I should be on the "index" page
+  And I should see "You already have a restaurant, how many do you need?"

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -78,6 +78,8 @@ def goto(page)
     new_user_registration_path
   when 'user registration'
     user_registration_path
+  when 'create restaurant'
+    new_restaurant_path
   else
     root_path
   end

--- a/features/step_definitions/restaurant_steps.rb
+++ b/features/step_definitions/restaurant_steps.rb
@@ -1,4 +1,4 @@
 Then(/^I should be on the restaurant page for "([^"]*)"$/) do |name|
-  restaurant_id = Menu.find_by(name: name)
-  expect(current_path).to eq restaurant_path(restaurant_id)
+  restaurant = Restaurant.find_by(name: name)
+  expect(current_path).to eq restaurant_path(restaurant)
 end

--- a/features/step_definitions/restaurant_steps.rb
+++ b/features/step_definitions/restaurant_steps.rb
@@ -1,0 +1,4 @@
+Then(/^I should be on the restaurant page for "([^"]*)"$/) do |name|
+  restaurant_id = Menu.find_by(name: name)
+  expect(current_path).to eq restaurant_path(restaurant_id)
+end

--- a/features/step_definitions/restaurant_steps.rb
+++ b/features/step_definitions/restaurant_steps.rb
@@ -7,3 +7,17 @@ Given(/^I am logged in as a restaurant owner$/) do
   user = FactoryGirl.create(:user, role: 'owner')
   login_as(user, scope: :user)
 end
+
+Given(/^I already have a restaurant$/) do
+  steps %q{
+    Given I am on the "create restaurant" page
+    When I fill in:
+      | element     | content              |
+      | Name        | Awesome restaurant   |
+      | Description | Good food            |
+      | Street      | Holtermansgatan 17d  |
+      | Zipcode     | 41235                |
+      | Town        | Göteborg             |
+    And I click the "Create" button
+  }
+end

--- a/features/step_definitions/restaurant_steps.rb
+++ b/features/step_definitions/restaurant_steps.rb
@@ -2,3 +2,8 @@ Then(/^I should be on the restaurant page for "([^"]*)"$/) do |name|
   restaurant = Restaurant.find_by(name: name)
   expect(current_path).to eq restaurant_path(restaurant)
 end
+
+Given(/^I am logged in as a restaurant owner$/) do
+  user = FactoryGirl.create(:user, role: 'owner')
+  login_as(user, scope: :user)
+end

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -48,12 +48,6 @@ Given(/^I register as a user with address "([^"]*)"$/) do |address|
   }
 end
 
-
-Given(/^I am logged in as a restaurant owner$/) do
-  user = FactoryGirl.create(:user, role: 'owner')
-  login_as(user, scope: :user)
-end
-
 Given(/^I am not logged in$/) do
   logout
 end

--- a/spec/factories/restaurants.rb
+++ b/spec/factories/restaurants.rb
@@ -2,6 +2,9 @@ FactoryGirl.define do
   factory :restaurant do
     name 'MyString'
     description 'MyText'
+    street 'My Street'
+    zipcode '99912'
+    town 'GothenburgCity'
     user {association(:user)}
   end
 end

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Restaurant, type: :model do
   describe "regression test" do
     it { is_expected.to have_db_column :name }
     it { is_expected.to have_db_column :description}
-    it { is_expected.to have_db_column :address}
+    it { is_expected.to have_db_column :street}
+    it { is_expected.to have_db_column :zipcode}
+    it { is_expected.to have_db_column :town}
     it {is_expected.to belong_to :user}
     it {is_expected.to validate_presence_of :user}
   end

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -2,8 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Restaurant, type: :model do
 
-  it {is_expected.to belong_to :user}
-  it {is_expected.to validate_presence_of :user}
+  describe "regression test" do
+    it { is_expected.to have_db_column :name }
+    it { is_expected.to have_db_column :description}
+    it { is_expected.to have_db_column :address}
+    it {is_expected.to belong_to :user}
+    it {is_expected.to validate_presence_of :user}
+  end
 
   describe 'Factory' do
     it 'should have valid Factory' do

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Restaurant, type: :model do
   end
 
   describe 'validations' do
+    it { is_expected.to validate_presence_of :name}
     it { is_expected.to validate_presence_of :street}
     it { is_expected.to validate_presence_of :zipcode}
     it { is_expected.to validate_presence_of :town}

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe Restaurant, type: :model do
     it {is_expected.to validate_presence_of :user}
   end
 
+  describe 'validations' do
+    it { is_expected.to validate_presence_of :street}
+    it { is_expected.to validate_presence_of :zipcode}
+    it { is_expected.to validate_presence_of :town}
+  end
+
   describe 'Factory' do
     it 'should have valid Factory' do
       expect(create(:restaurant)).to be_valid


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/131526907

Changes proposed in this pull request:
- Added restaurant creation page, routing, controller
- Restrict restaurant creation to logged in restaurant owners & error handle for exception cases
- Create simple show page to display restaurant information (but this needs to be expanded in another feature)
- Require address and name for restaurant

Todo:
- Complete sad path testing for restaurant creation - no name, no associated user, etc. (Error messages should be created and should appear but we haven't tested for them for these scenarios).

What I have learned working on this feature:
- How to make changes to DB tables
- merging parameters into table entry
- CanCan's load_and_authorize_resource

Screenshots:
![screen shot 2016-10-03 at 3 02 24 pm](https://cloud.githubusercontent.com/assets/20141428/19038139/6ed8ebc2-897a-11e6-98c0-030d139530de.png)

Ready for review!
