### PR TITLE
Add geocoding to restaurant creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'haml-rails', '~> 0.9'
 gem 'acts_as_shopping_cart', '~> 0.4.1'
 gem 'devise'
 gem 'cancancan', '~> 1.10'
+gem 'geocoder'
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
       factory_girl (~> 4.7.0)
       railties (>= 3.0.0)
     ffi (1.9.14)
+    geocoder (1.4.0)
     gherkin (4.0.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -289,6 +290,7 @@ DEPENDENCIES
   devise
   erb2haml
   factory_girl_rails
+  geocoder
   haml-rails (~> 0.9)
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,5 +1,11 @@
 class Restaurant < ApplicationRecord
   belongs_to :user
-
+  geocoded_by :full_address
+  after_validation :geocode
   validates_presence_of :user, :name, :street, :zipcode, :town
+
+  private
+  def full_address
+    [street, zipcode, town, 'Sweden'].compact.join(', ')
+  end
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -4,8 +4,7 @@ class Restaurant < ApplicationRecord
   after_validation :geocode
   validates_presence_of :user, :name, :street, :zipcode, :town
 
-  private
   def full_address
-    [street, zipcode, town, 'Sweden'].compact.join(', ')
+    [street, zipcode, town].join(', ')
   end
 end

--- a/app/views/restaurants/index.html.haml
+++ b/app/views/restaurants/index.html.haml
@@ -11,3 +11,4 @@
     %div Placeholder for popular restaurants
     %div Highlighted dishes placeholder
     %div Comment and rate placeholder
+    %div#map

--- a/db/migrate/20161003144725_add_latitude_and_longitude_to_restaurant.rb
+++ b/db/migrate/20161003144725_add_latitude_and_longitude_to_restaurant.rb
@@ -1,0 +1,6 @@
+class AddLatitudeAndLongitudeToRestaurant < ActiveRecord::Migration[5.0]
+  def change
+    add_column :restaurants, :latitude, :float
+    add_column :restaurants, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161003094107) do
+ActiveRecord::Schema.define(version: 20161003144725) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,8 @@ ActiveRecord::Schema.define(version: 20161003094107) do
     t.string   "street"
     t.integer  "zipcode"
     t.string   "town"
+    t.float    "latitude"
+    t.float    "longitude"
     t.index ["user_id"], name: "index_restaurants_on_user_id", using: :btree
   end
 

--- a/features/geocoding.feature
+++ b/features/geocoding.feature
@@ -1,6 +1,4 @@
-Feature: As a restaurant Owner
-  in order to be found
-  my restaurant need to be placed on a map.
+Feature: Geocoding restaurants
 
 Background:
   Given the following restaurant exist
@@ -11,7 +9,6 @@ Scenario: Show map on index page
   When I am on the "index" page
   Then I should see a map-div
 
-Scenario: Geolocate restaurant
+Scenario: Geocode restaurant
   Given I am on restaurant page for "McD"
   Then "McD" should have a latitude
-  

--- a/features/map.feature
+++ b/features/map.feature
@@ -7,7 +7,10 @@ Background:
   | name |
   | McD  |
 
-Scenario: Show map on restaurant page
+Scenario: Geolocate restaurant
   Given I am on restaurant page for "McD"
   Then "McD" should have a latitude
-  And I should see a map-div
+
+Scenario: Show map on index page
+  When I am on the "index" page
+  Then I should see a map-div

--- a/features/map.feature
+++ b/features/map.feature
@@ -7,10 +7,11 @@ Background:
   | name |
   | McD  |
 
-Scenario: Geolocate restaurant
-  Given I am on restaurant page for "McD"
-  Then "McD" should have a latitude
-
 Scenario: Show map on index page
   When I am on the "index" page
   Then I should see a map-div
+
+Scenario: Geolocate restaurant
+  Given I am on restaurant page for "McD"
+  Then "McD" should have a latitude
+  

--- a/features/map.feature
+++ b/features/map.feature
@@ -9,4 +9,5 @@ Background:
 
 Scenario: Show map on restaurant page
   Given I am on restaurant page for "McD"
-  Then I should see "google map"
+  Then "McD" should have a latitude
+  And I should see a map-div

--- a/features/map.feature
+++ b/features/map.feature
@@ -1,0 +1,12 @@
+Feature: As a restaurant Owner
+  in order to be found
+  my restaurant need to be placed on a map.
+
+Background:
+  Given the following restaurant exist
+  | name |
+  | McD  |
+
+Scenario: Show map on restaurant page
+  Given I am on restaurant page for "McD"
+  Then I should see "google map"

--- a/features/step_definitions/map_steps.rb
+++ b/features/step_definitions/map_steps.rb
@@ -8,3 +8,13 @@ Given(/^I am on restaurant page for "([^"]*)"$/) do |name|
   restaurant = Restaurant.find_by(name: name)
   visit restaurant_path(restaurant)
 end
+
+Then(/^"([^"]*)" should have a latitude$/) do |name|
+  restaurant = Restaurant.find_by(name: name)
+  expect(restaurant.latitude).not_to be nil
+end
+
+Then(/^I should see a map-div$/) do
+  loop until all(:css, '#map').length == 1
+  expect (page).to have_css '#map'
+end

--- a/features/step_definitions/map_steps.rb
+++ b/features/step_definitions/map_steps.rb
@@ -16,5 +16,5 @@ end
 
 Then(/^I should see a map-div$/) do
   loop until all(:css, '#map').length == 1
-  expect (page).to have_css '#map'
+  expect(page).to have_css '#map'
 end

--- a/features/step_definitions/map_steps.rb
+++ b/features/step_definitions/map_steps.rb
@@ -1,0 +1,10 @@
+Given(/^the following restaurant exist$/) do |table|
+  table.hashes.each do |hash|
+    FactoryGirl.create(:restaurant, hash)
+  end
+end
+
+Given(/^I am on restaurant page for "([^"]*)"$/) do |name|
+  restaurant = Restaurant.find_by(name: name)
+  visit restaurant_path(restaurant)
+end

--- a/features/step_definitions/map_steps.rb
+++ b/features/step_definitions/map_steps.rb
@@ -12,6 +12,7 @@ end
 Then(/^"([^"]*)" should have a latitude$/) do |name|
   restaurant = Restaurant.find_by(name: name)
   expect(restaurant.latitude).not_to be nil
+  binding.pry
 end
 
 Then(/^I should see a map-div$/) do

--- a/features/step_definitions/map_steps.rb
+++ b/features/step_definitions/map_steps.rb
@@ -12,7 +12,6 @@ end
 Then(/^"([^"]*)" should have a latitude$/) do |name|
   restaurant = Restaurant.find_by(name: name)
   expect(restaurant.latitude).not_to be nil
-  binding.pry
 end
 
 Then(/^I should see a map-div$/) do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,3 +12,18 @@ Cucumber::Rails::Database.javascript_strategy = :truncation
 Warden.test_mode!
 World Warden::Test::Helpers
 After { Warden.test_reset! }
+
+Geocoder.configure(lookup: :test)
+
+Geocoder::Lookup::Test.set_default_stub(
+  [
+    {
+      'latitude'     => 57.7089,
+      'longitude'    => 11.9746,
+      'address'      => 'Gothenburg, Sweden',
+      'state'        => 'Gothenburg',
+      'country'      => 'Sweden',
+      'country_code' => 'SE'
+    }
+  ]
+)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,17 +13,17 @@ Warden.test_mode!
 World Warden::Test::Helpers
 After { Warden.test_reset! }
 
-Geocoder.configure(lookup: :test)
-
-Geocoder::Lookup::Test.set_default_stub(
-  [
-    {
-      'latitude'     => 57.7089,
-      'longitude'    => 11.9746,
-      'address'      => 'Gothenburg, Sweden',
-      'state'        => 'Gothenburg',
-      'country'      => 'Sweden',
-      'country_code' => 'SE'
-    }
-  ]
-)
+# Geocoder.configure(lookup: :test)
+#
+# Geocoder::Lookup::Test.set_default_stub(
+#   [
+#     {
+#       'latitude'     => 57.7089,
+#       'longitude'    => 11.9746,
+#       'address'      => 'Gothenburg, Sweden',
+#       'state'        => 'Gothenburg',
+#       'country'      => 'Sweden',
+#       'country_code' => 'SE'
+#     }
+#   ]
+# )

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,17 +13,17 @@ Warden.test_mode!
 World Warden::Test::Helpers
 After { Warden.test_reset! }
 
-# Geocoder.configure(lookup: :test)
-#
-# Geocoder::Lookup::Test.set_default_stub(
-#   [
-#     {
-#       'latitude'     => 57.7089,
-#       'longitude'    => 11.9746,
-#       'address'      => 'Gothenburg, Sweden',
-#       'state'        => 'Gothenburg',
-#       'country'      => 'Sweden',
-#       'country_code' => 'SE'
-#     }
-#   ]
-# )
+Geocoder.configure(lookup: :test)
+
+Geocoder::Lookup::Test.set_default_stub(
+  [
+    {
+      'latitude'     => 57.7089,
+      'longitude'    => 11.9746,
+      'address'      => 'Gothenburg, Sweden',
+      'state'        => 'Gothenburg',
+      'country'      => 'Sweden',
+      'country_code' => 'SE'
+    }
+  ]
+)

--- a/spec/factories/restaurants.rb
+++ b/spec/factories/restaurants.rb
@@ -2,9 +2,9 @@ FactoryGirl.define do
   factory :restaurant do
     name 'MyString'
     description 'MyText'
-    street 'My Street'
-    zipcode '99912'
-    town 'GothenburgCity'
+    street 'Fjällgatan 3'
+    zipcode '41463'
+    town 'Gothenburg'
     user {association(:user)}
   end
 end

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Restaurant, type: :model do
     it { is_expected.to have_db_column :street}
     it { is_expected.to have_db_column :zipcode}
     it { is_expected.to have_db_column :town}
+    it { is_expected.to have_db_column :latitude}
+    it { is_expected.to have_db_column :longitude}
     it {is_expected.to belong_to :user}
     it {is_expected.to validate_presence_of :user}
   end

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -27,5 +27,11 @@ RSpec.describe Restaurant, type: :model do
     end
   end
 
+  describe 'geocoding' do
+    it 'should generate a full address from Factory' do
+      expect(create(:restaurant).full_address).to eq "Fjällgatan 3, 41463, Gothenburg"
+    end
+  end
+
 
 end

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -33,5 +33,4 @@ RSpec.describe Restaurant, type: :model do
     end
   end
 
-
 end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/131070127

Changes proposed in this pull request:
- Install geocoder gem
- Add latitude and longitude to Restaurant model
- Geocode restaurants on creation
- Stub geocoder calls in testing

What I have learned working on this feature: How to stub geocoder calls during testing

Ready for review!
