### PR TITLE
Remove double step def for user creation

### DIFF
--- a/features/cart_page.feature
+++ b/features/cart_page.feature
@@ -19,7 +19,7 @@ Scenario: Can only checkout as registered user
   And I am on the "cart" page
   When I click the link "Log in to pay"
   Then I should be on the "register" page
-  When I there register as a user with username "Amber" and email "amber@random.com"
+  When I register as a user with username "Amber" and email "amber@random.com"
   Then I should be on the "cart" page
   And I should see "Pay Now"
   And I should not see "Log in to pay"

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -21,19 +21,6 @@ Given(/^I register as a user with username "([^"]*)" and email "([^"]*)"$/) do |
   }
 end
 
-Given(/^I there register as a user with username "([^"]*)" and email "([^"]*)"$/) do |name, email|
-  steps %Q{
-    When I fill in:
-      | element                    | content          |
-      | Name                       | #{name}           |
-      | Email                      | #{email} |
-      | Address                    | Fjällgatan 3, Göteborg, Västa Götaland, Sverige |
-      | Password                   | password         |
-      | Password confirmation      | password         |
-    And I click the "Register" button
-  }
-end
-
 Given(/^I register as a user with address "([^"]*)"$/) do |address|
   steps %Q{
     And I am on the "register" page


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/131501633

Changes proposed in this pull request:
- Remove double step definition (one with a weird name)
- Fix failing cucumber tests so they all use the non-weird-name version of the step

What I have learned working on this feature: I might be doing it wrong, because this took two minutes.

Ready for review @tochman !
