### PR TITLE
Remove 'add to cart' button for logged-in restaurant owners

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,6 +7,7 @@ class Ability
       can :manage, Menu
       can :manage, Dish
       can :manage, Restaurant
+      cannot :create, ShoppingCart
       can :read, :all
     elsif user.customer?
       cannot :manage, Menu

--- a/app/views/dishes/show.html.haml
+++ b/app/views/dishes/show.html.haml
@@ -14,5 +14,5 @@ Menu(s):
 - @dish.menus.each do |menu|
   = menu.title
 %br/
-- unless !current_user.nil? && current_user.owner?
+- if can? :create, ShoppingCart
   = link_to 'Add to cart', dish_add_item_path(@dish), method: :post, class: "btn btn-success"

--- a/app/views/dishes/show.html.haml
+++ b/app/views/dishes/show.html.haml
@@ -14,4 +14,5 @@ Menu(s):
 - @dish.menus.each do |menu|
   = menu.title
 %br/
-= link_to 'Add to cart', dish_add_item_path(@dish), method: :post, class: "btn btn-success"
+- unless !current_user.nil? && current_user.role == 'owner'
+  = link_to 'Add to cart', dish_add_item_path(@dish), method: :post, class: "btn btn-success"

--- a/app/views/dishes/show.html.haml
+++ b/app/views/dishes/show.html.haml
@@ -14,5 +14,5 @@ Menu(s):
 - @dish.menus.each do |menu|
   = menu.title
 %br/
-- unless !current_user.nil? && current_user.role == 'owner'
+- unless !current_user.nil? && current_user.owner?
   = link_to 'Add to cart', dish_add_item_path(@dish), method: :post, class: "btn btn-success"

--- a/features/add_dish.feature
+++ b/features/add_dish.feature
@@ -24,3 +24,4 @@ Scenario: I create a dish and put it on a menu
   When I click the "Add a Dish" button
   Then I should see "Pizza"
   And I should see "Lunch"
+  And I should not see "Add to cart"

--- a/spec/models/abilities/owner_abilities_spec.rb
+++ b/spec/models/abilities/owner_abilities_spec.rb
@@ -15,4 +15,8 @@ RSpec.describe 'Owners Abilities', type: :model do
     expect(subject).to be_able_to(:manage, Restaurant.new)
   end
 
+  it 'can not create ShoppingCart' do
+    expect(subject).not_to be_able_to(:create, ShoppingCart)
+  end
+
 end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/131445807

Changes proposed in this pull request:
- Logged in restaurant owners cannot see add to cart button (they're not allowed to have a shopping cart - so it throws an error)

What I have learned working on this feature: I probably hadn't used an "unless" statement before, actually.

Ready for review @tochman !
