### PR TITLE
Fix tax calculation method for shopping cart

### DIFF
--- a/app/models/shopping_cart.rb
+++ b/app/models/shopping_cart.rb
@@ -1,3 +1,7 @@
 class ShoppingCart < ActiveRecord::Base
   acts_as_shopping_cart_using :shopping_cart_item
+
+  def taxes
+    0
+  end
 end

--- a/app/views/carts/checkout.html.haml
+++ b/app/views/carts/checkout.html.haml
@@ -3,10 +3,9 @@ Hey, you're checking out.
 You ordered:
 %br
   - @order.shopping_cart_items.each do |dish|
-    = dish.price_cents
     = dish.item.dish_name
 Total price:
-= @order.total
+= @order.total.to_i
 %p
   Delivery address:
   = current_user.address

--- a/app/views/carts/index.html.haml
+++ b/app/views/carts/index.html.haml
@@ -15,6 +15,9 @@
       - @cart.shopping_cart_items.each do |dish|
         = dish.price_cents
         = dish.item.dish_name
+      %p
+        Total:
+        = @cart.total
       - if current_user
         = link_to 'Pay Now', checkout_path(@cart), method: :post
       - else

--- a/app/views/carts/index.html.haml
+++ b/app/views/carts/index.html.haml
@@ -17,7 +17,7 @@
         = dish.item.dish_name
       %p
         Total:
-        = @cart.total
+        = @cart.total.to_i
       - if current_user
         = link_to 'Pay Now', checkout_path(@cart), method: :post
       - else

--- a/app/views/carts/index.html.haml
+++ b/app/views/carts/index.html.haml
@@ -13,7 +13,6 @@
       = link_to 'Search for dishes!', root_path
     - else
       - @cart.shopping_cart_items.each do |dish|
-        = dish.price_cents
         = dish.item.dish_name
       %p
         Total:

--- a/features/cart_page.feature
+++ b/features/cart_page.feature
@@ -2,10 +2,13 @@ Feature: As a Customer
   in order to place an order
   I need to be able to add dishes to my cart.
 
-Scenario: Adding dish to cart
+Background:
   Given the following dish exist
   | dish_name | dish_desc       | dish_price |
   | Pizza     | Delicious pizza | 7000       |
+  | Salad     | Leafy           | 200        |
+
+Scenario: Adding dish to cart
   And I am on the "dish" page for "Pizza"
   When I click the link "Add to cart"
   Then I should see "Delicious pizza"
@@ -58,3 +61,11 @@ Scenario: My cart clears after checkout
   And I check out
   When I am on the "cart" page
   Then I should see "You have no dishes in your cart."
+
+Scenario: My cart gives me an appropriate total
+  Given I am on the "dish" page for "Pizza"
+  And I click the link "Add to cart"
+  And I am on the "dish" page for "Salad"
+  And I click the link "Add to cart"
+  When I am on the "cart" page
+  Then I should see "Total: 7200"

--- a/features/cart_page.feature
+++ b/features/cart_page.feature
@@ -7,20 +7,17 @@ Background:
     | name |
     | Anna |
   And "Anna" has a restaurant
-
-Scenario: Adding dish to cart
-  Given the following dish exist
+  And the following dish exist
   | dish_name | dish_desc       | dish_price |
   | Pizza     | Delicious pizza | 7000       |
   | Salad     | Leafy           | 200        |
 
 Scenario: Adding dish to cart
-  And I am on the "dish" page for "Pizza"
+  Given I am on the dish page for "Pizza"
   When I click the link "Add to cart"
   Then I should see "Delicious pizza"
   And I click the link "Show cart"
   Then I should be on the "cart" page
-  And I should see "700000"
   And I should see "Pizza"
 
 Scenario: Can only checkout as registered user
@@ -42,7 +39,6 @@ Scenario: Checking out as registered user
     | content                  |
     | Your food is on its way! |
     | Pizza                    |
-    | 700000                   |
     | Fjällgatan 3             |
 
 Scenario: I view the cart before I add dishes
@@ -69,9 +65,9 @@ Scenario: My cart clears after checkout
   Then I should see "You have no dishes in your cart."
 
 Scenario: My cart gives me an appropriate total
-  Given I am on the "dish" page for "Pizza"
+  Given I am on the dish page for "Pizza"
   And I click the link "Add to cart"
-  And I am on the "dish" page for "Salad"
+  And I am on the dish page for "Salad"
   And I click the link "Add to cart"
   When I am on the "cart" page
   Then I should see "Total: 7200"

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -43,11 +43,6 @@ When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |element, text|
   fill_in element, with: text
 end
 
-Given(/^I am on the "([^"]*)" page for "([^"]*)"$/) do |page, dish|
-  dish_id = Dish.find_by(dish_name: dish)
-  visit dish_path(dish_id)
-end
-
 Then(/^I should be on the "([^"]*)" page for "([^"]*)"$/) do |page, dish|
   dish_id = Dish.find_by(dish_name: dish)
   expect(current_path).to eq dish_path(dish_id)

--- a/features/step_definitions/cart_steps.rb
+++ b/features/step_definitions/cart_steps.rb
@@ -9,7 +9,7 @@ Given(/^there is one dish in my cart$/) do
   steps %Q{Given the following dish exist
     | dish_name | dish_desc       | dish_price |
     | Pizza     | Delicious pizza | 7000       |
-    And I am on the "dish" page for "Pizza"
+    And I am on the dish page for "Pizza"
     Then I click the link "Add to cart"}
 end
 
@@ -18,9 +18,9 @@ Given(/^there are two dishes in my cart$/) do
     | dish_name | dish_desc       | dish_price |
     | Pizza     | Delicious pizza | 7000       |
     | Salad     | Leaves & stuff  | 1500       |
-    And I am on the "dish" page for "Pizza"
+    And I am on the dish page for "Pizza"
     Then I click the link "Add to cart"
-    And I am on the "dish" page for "Salad"
+    And I am on the dish page for "Salad"
     Then I click the link "Add to cart"
     And the database says there are "2" dishes in my cart}
 end

--- a/features/step_definitions/dish_steps.rb
+++ b/features/step_definitions/dish_steps.rb
@@ -3,15 +3,6 @@ Then(/^I should be on the dish page for "([^"]*)"$/) do |name|
   expect(current_path).to eq dish_path(dish)
 end
 
-When(/^I check the "([^"]*)" box$/) do |menu|
-  page.check(menu)
-end
-
-When(/^visit the "([^"]*)" menu page$/) do |menu_name|
-  menu = Menu.find_by(title: menu_name)
-  visit menu_path(menu)
-end
-
 Given(/^I have the following dishes:$/) do |table|
   restaurant = Restaurant.first
   table.hashes.each do |dish|
@@ -22,4 +13,9 @@ end
 Given(/^"([^"]*)" has a dish "([^"]*)"$/) do |name, dish_name|
   restaurant = User.find_by(name: name).restaurant
   FactoryGirl.create(:dish, dish_name: dish_name, restaurant: restaurant)
+end
+
+Given(/^I am on the dish page for "([^"]*)"$/) do |dish|
+  dish_id = Dish.find_by(dish_name: dish)
+  visit dish_path(dish_id)
 end

--- a/features/step_definitions/menu_steps.rb
+++ b/features/step_definitions/menu_steps.rb
@@ -42,3 +42,12 @@ Given(/^"([^"]*)" has a menu "([^"]*)"$/) do |owner_name, menu_name|
   owner = User.find_by(name: owner_name).restaurant
   FactoryGirl.create(:menu, restaurant: owner, title: menu_name)
 end
+
+When(/^I check the "([^"]*)" box$/) do |menu|
+  page.check(menu)
+end
+
+When(/^visit the "([^"]*)" menu page$/) do |menu_name|
+  menu = Menu.find_by(title: menu_name)
+  visit menu_path(menu)
+end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/131723629

Changes proposed in this pull request:
- Remove tax calculation for shopping cart (can add a tax back in with a number we like later on)
- Display proper total (without öre) on cart and checkout pages

What I have learned working on this feature: Got a little more familiar with acts_as_shopping_cart

Ready for review!
