### PR TITLE
WIP: Geo edit & move api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ coverage/
 #Ignore mac files
 .DS_Store
 
+#Ignore .env
+.env
+
 #vendor files
 vendor/bundle/

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -22,8 +22,6 @@ class RestaurantsController < ApplicationController
   end
 
   def show
-    binding.pry
-    @restaurant.geocode
   end
 
   def edit

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -54,4 +54,8 @@ class RestaurantsController < ApplicationController
   def restaurant_params
     params.require(:restaurant).permit(:name, :description, :street, :zipcode, :town)
   end
+
+  def re_geolocate
+    @restaurant.geocode
+  end
 end

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -22,6 +22,8 @@ class RestaurantsController < ApplicationController
   end
 
   def show
+    binding.pry
+    @restaurant.geocode
   end
 
   def edit
@@ -55,7 +57,4 @@ class RestaurantsController < ApplicationController
     params.require(:restaurant).permit(:name, :description, :street, :zipcode, :town)
   end
 
-  def re_geolocate
-    @restaurant.geocode
-  end
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -1,11 +1,21 @@
 class Restaurant < ApplicationRecord
   belongs_to :user
   has_many :menus
+
   geocoded_by :full_address
-  after_validation :geocode
+  after_validation :geocode, if: ->(obj){ obj.full_address.present? and obj.full_address_changed? }
+
   validates_presence_of :user, :name, :street, :zipcode, :town
 
   def full_address
     [street, zipcode, town].join(', ')
+  end
+
+  def full_address_changed?
+    if  self.zipcode_changed? || self.address_changed? || self.town_changed?
+      true
+    else
+      false
+    end
   end
 end

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -4,7 +4,7 @@ class Restaurant < ApplicationRecord
   has_many :dishes
 
   geocoded_by :full_address
-  after_validation :geocode, if: ->(obj){ obj.full_address.present? and obj.full_address_changed? }
+  after_validation :geocode
 
   validates_presence_of :user, :name, :street, :zipcode, :town
 
@@ -12,11 +12,4 @@ class Restaurant < ApplicationRecord
     [street, zipcode, town].join(', ')
   end
 
-  def full_address_changed?
-    if  self.zipcode_changed? || self.street_changed? || self.town_changed?
-      true
-    else
-      false
-    end
-  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,7 @@
     = csrf_meta_tags
     = include_gon(init: true)
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' =>'reload'
-    = javascript_include_tag 'http://maps.google.com/maps/api/js?key=AIzaSyDksFPPj-FomswnVnuVeNMdGBYb1nA4pas'
+    = javascript_include_tag "//maps.google.com/maps/api/js?v=3.23&key=#{ ENV['GOOGLE_MAPS_API_KEY']}"
     = javascript_include_tag 'application', 'data-turbolinks-track' => 'reload'
   %body
     = render partial: 'navbar'

--- a/features/restaurant_edit.feature
+++ b/features/restaurant_edit.feature
@@ -25,6 +25,12 @@ Feature: As a restaurant Owner
     Given I am on the restaurant page for "Awesome"
     Then "Awesome" should have lat "57.7089" and long "11.9746"
     And I click the link "Edit"
-    When I fill in "Street" with "Blåsbackegatan 17"
+    When I fill in:
+      | element     | content            |
+      | Street      | Blåsbackegatan 17  |
+      | Zipcode     | 30247              |
+      | Town        | Halmstad           |
     And I click the "Submit" button
+    Then I should be on the restaurant page for "Awesome"
+    And I should see "Blåsbackegatan 17"
     Then "Awesome" should have lat "56.6755" and long "12.8783"

--- a/features/restaurant_edit.feature
+++ b/features/restaurant_edit.feature
@@ -20,3 +20,11 @@ Feature: As a restaurant Owner
     And I fill in "Name" with ""
     And I click the "Submit" button
     Then I should see "Name can't be blank"
+
+  Scenario: My geolocation gets updated when I update my address
+    Given I am on the restaurant page for "Awesome"
+    Then "Awesome" should have lat "57.7089" and long "11.9746"
+    And I click the link "Edit"
+    When I fill in "Street" with "Blåsbackegatan 17"
+    And I click the "Submit" button
+    Then "Awesome" should have lat "56.6755" and long "12.8783"

--- a/features/restaurant_edit.feature
+++ b/features/restaurant_edit.feature
@@ -31,7 +31,7 @@ Feature: As a restaurant Owner
       | Zipcode     | 30247              |
       | Town        | Halmstad           |
     And I click the "Submit" button
-    Then I should be on the restaurant page for "Awesome"
+    When I am on the restaurant page for "Awesome"
     And I should see "Blåsbackegatan 17"
     Then "Awesome" should have lat "56.6755" and long "12.8783"
 

--- a/features/step_definitions/restaurant_steps.rb
+++ b/features/step_definitions/restaurant_steps.rb
@@ -33,6 +33,7 @@ Given(/^I am on the restaurant page for "([^"]*)"$/) do |name|
 end
 
 Then(/^"([^"]*)" should have lat "([^"]*)" and long "([^"]*)"$/) do |name, lat, long|
+  binding.pry
   restaurant = Restaurant.find_by(name: name)
   expect(restaurant.latitude).to be lat.to_f
   expect(restaurant.longitude).to be long.to_f

--- a/features/step_definitions/restaurant_steps.rb
+++ b/features/step_definitions/restaurant_steps.rb
@@ -32,6 +32,12 @@ Given(/^I am on the restaurant page for "([^"]*)"$/) do |name|
   visit(restaurant_path(restaurant))
 end
 
+Then(/^"([^"]*)" should have lat "([^"]*)" and long "([^"]*)"$/) do |name, lat, long|
+  restaurant = Restaurant.find_by(name: name)
+  expect(restaurant.latitude).to be lat.to_f
+  expect(restaurant.longitude).to be long.to_f
+end
+
 Then(/^I should be on the edit restaurant page for "([^"]*)"$/) do |restaurant|
   restaurant = Restaurant.find_by(name: restaurant)
   expect(current_path).to eq edit_restaurant_path(id: restaurant)


### PR DESCRIPTION
PT Story: 
https://www.pivotaltracker.com/story/show/131553627

Changes proposed in this pull request:
WIP: 
Trying to make the following test pass: 

```
  Scenario: My geolocation gets updated when I update my address
    Given I am on the restaurant page for "Awesome"
    Then "Awesome" should have lat "57.7089" and long "11.9746"
    And I click the link "Edit"
    When I fill in:
      | element     | content            |
      | Street      | Blåsbackegatan 17  |
      | Zipcode     | 30247              |
      | Town        | Halmstad           |
    And I click the "Submit" button
    When I am on the restaurant page for "Awesome"
    And I should see "Blåsbackegatan 17"
    Then "Awesome" should have lat "56.6755" and long "12.8783"
```

What I have learned working on this feature: 
- The devil is in the details and when you don't find the missing one it is very frustrating
- The garden club works (same test there passes), it rides on the devise edit user function - if it matters 

WIP:
Slightly out of scope, but within geo:
I also added the API-key to env and removed the http: to make Heroku feel better about it later. 
(will bundle with dotenv in order to make it work)
