### PR TITLE
Rename dish columns sensibly

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -6,8 +6,8 @@ class CartsController < ApplicationController
 
   def add_item
     @dish = Dish.find(params[:dish_id])
-    @cart.add(@dish, @dish.dish_price)
-    flash[:notice] = "#{@dish.dish_name} added to cart"
+    @cart.add(@dish, @dish.price)
+    flash[:notice] = "#{@dish.name} added to cart"
     redirect_back(fallback_location: restaurants_path)
   end
 

--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -37,7 +37,7 @@ class DishesController < ApplicationController
   private
 
   def dish_params
-    params.require(:dish).permit(:dish_name, :dish_desc, :dish_price, :dish_allergy, :dish_ingredients, :dish_cal, {menu_ids: []})
+    params.require(:dish).permit(:name, :description, :price, :allergies, :ingredients, :calories, {menu_ids: []})
   end
 
   def find_dish_from_params

--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -1,7 +1,7 @@
 class Dish < ApplicationRecord
-  validates_presence_of :dish_name
-  validates_presence_of :dish_desc
-  validates_presence_of :dish_price
+  validates_presence_of :name
+  validates_presence_of :description
+  validates_presence_of :price
   validates_presence_of :restaurant
 
   has_and_belongs_to_many :menus

--- a/app/views/carts/checkout.html.haml
+++ b/app/views/carts/checkout.html.haml
@@ -3,7 +3,7 @@ Hey, you're checking out.
 You ordered:
 %br
   - @order.shopping_cart_items.each do |dish|
-    = dish.item.dish_name
+    = dish.item.name
 Total price:
 = @order.total.to_i
 %p

--- a/app/views/carts/index.html.haml
+++ b/app/views/carts/index.html.haml
@@ -13,7 +13,7 @@
       = link_to 'Search for dishes!', root_path
     - else
       - @cart.shopping_cart_items.each do |dish|
-        = dish.item.dish_name
+        = dish.item.name
       %p
         Total:
         = @cart.total.to_i

--- a/app/views/dishes/_form.html.haml
+++ b/app/views/dishes/_form.html.haml
@@ -1,16 +1,16 @@
 = form_for @dish, class: 'form-group' do |form|
-  = form.label :dish_name, 'Dish Name'
-  = form.text_field :dish_name, class: 'form-control'
-  = form.label :dish_desc, 'Dish description'
-  = form.text_area :dish_desc, class: 'form-control'
-  = form.label :dish_price, 'Price'
-  = form.text_field :dish_price, class: 'form-control'
-  = form.label :dish_allergy, 'Allergy Info'
-  = form.text_area :dish_allergy, class: 'form-control'
-  = form.label :dish_cal, 'Calories'
-  = form.text_field :dish_cal, class: 'form-control'
-  = form.label :dish_ingredients, 'Ingredients'
-  = form.text_field :dish_ingredients, class: 'form-control'
+  = form.label :name, 'Dish Name'
+  = form.text_field :name, class: 'form-control'
+  = form.label :description, 'Dish description'
+  = form.text_area :description, class: 'form-control'
+  = form.label :price, 'Price'
+  = form.text_field :price, class: 'form-control'
+  = form.label :allergies, 'Allergy Info'
+  = form.text_area :allergies, class: 'form-control'
+  = form.label :calories, 'Calories'
+  = form.text_field :calories, class: 'form-control'
+  = form.label :ingredients, 'Ingredients'
+  = form.text_field :ingredients, class: 'form-control'
   %p#menus
     - if !@menus.nil?
       %h3 Add to Menu

--- a/app/views/dishes/show.html.haml
+++ b/app/views/dishes/show.html.haml
@@ -1,14 +1,14 @@
 %h1
-  Dish page for #{@dish.dish_name}
-Dish description: #{@dish.dish_desc}
+  Dish page for #{@dish.name}
+Dish description: #{@dish.description}
 %br/
-Dish price: #{@dish.dish_price}
+Dish price: #{@dish.price}
 %br/
-Allergens: #{@dish.dish_allergy}
+Allergens: #{@dish.allergies}
 %br/
-Ingredients: #{@dish.dish_ingredients}
+Ingredients: #{@dish.ingredients}
 %br/
-Calories: #{@dish.dish_cal}
+Calories: #{@dish.calories}
 %br/
 %br/
 Menu(s):

--- a/app/views/menus/edit.html.haml
+++ b/app/views/menus/edit.html.haml
@@ -7,7 +7,7 @@
       = f.text_field :title, id: 'title', class: 'form-control'
       - if !@menu.dishes.nil?
         %h3 Check to add dishes to menu:
-        = f.collection_check_boxes :dish_ids, @dishes, :id, :dish_name do |b|
+        = f.collection_check_boxes :dish_ids, @dishes, :id, :name do |b|
           .checkbox
             = b.check_box + b.label
       = f.submit 'Update', id: 'create', class: 'btn btn-warning'

--- a/app/views/menus/new.html.haml
+++ b/app/views/menus/new.html.haml
@@ -8,7 +8,7 @@
       %p#dishes
         - unless @dishes.nil?
           %h3 Add Dishes
-          = f.collection_check_boxes :dish_ids, @dishes, :id, :dish_name do |b|
+          = f.collection_check_boxes :dish_ids, @dishes, :id, :name do |b|
             .checkbox
               = b.check_box + b.label
       = f.submit 'Create', id: 'create', class: 'btn btn-warning'

--- a/app/views/menus/show.html.haml
+++ b/app/views/menus/show.html.haml
@@ -6,5 +6,5 @@
   Dishes:
   %br/
   - @menu.dishes.each do |dish|
-    = link_to dish.dish_name, dish
+    = link_to dish.name, dish
     %br/

--- a/db/migrate/20161007141716_change_dish_column_names.rb
+++ b/db/migrate/20161007141716_change_dish_column_names.rb
@@ -1,0 +1,10 @@
+class ChangeDishColumnNames < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :dishes, :dish_name, :name
+    rename_column :dishes, :dish_desc, :description
+    rename_column :dishes, :dish_price, :price
+    rename_column :dishes, :dish_allergy, :allergies
+    rename_column :dishes, :dish_cal, :calories
+    rename_column :dishes, :dish_ingredients, :ingredients
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,20 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161006152332) do
+ActiveRecord::Schema.define(version: 20161007141716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "dishes", force: :cascade do |t|
-    t.string   "dish_name"
-    t.text     "dish_desc"
-    t.integer  "dish_price"
-    t.text     "dish_allergy"
-    t.integer  "dish_cal"
-    t.text     "dish_ingredients"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.string   "name"
+    t.text     "description"
+    t.integer  "price"
+    t.text     "allergies"
+    t.integer  "calories"
+    t.text     "ingredients"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
     t.integer  "restaurant_id"
     t.index ["restaurant_id"], name: "index_dishes_on_restaurant_id", using: :btree
   end

--- a/features/cart_page.feature
+++ b/features/cart_page.feature
@@ -9,7 +9,7 @@ Feature: As a Customer
       | Anna |
     And "Anna" has a restaurant
     And the following dish exist
-      | dish_name | dish_desc       | dish_price |
+      | name | description       | price |
       | Pizza     | Delicious pizza | 7000       |
       | Salad     | Leafy           | 200        |
 

--- a/features/dish_creation.feature
+++ b/features/dish_creation.feature
@@ -44,7 +44,7 @@ Feature: As a restaurant Owner
       | Dish description | Delicious pizza |
       | Price            | 7000kr          |
     And I click the "Submit" button
-    Then I should see "Dish name can't be blank"
+    Then I should see "Name can't be blank"
 
   Scenario: I attempt to create a dish without description
     Given I am on the "Create Dish" page
@@ -54,7 +54,7 @@ Feature: As a restaurant Owner
       | Dish description |         |
       | Price            | 7000kr  |
     And I click the "Submit" button
-    Then I should see "Dish desc can't be blank"
+    Then I should see "Description can't be blank"
 
   Scenario: I attempt to create a dish without price
     Given I am on the "Create Dish" page
@@ -64,4 +64,4 @@ Feature: As a restaurant Owner
       | Dish description | Delicious pizza |
       | Price            |                 |
     And I click the "Submit" button
-    Then I should see "Dish price can't be blank"
+    Then I should see "Price can't be blank"

--- a/features/edit_dish.feature
+++ b/features/edit_dish.feature
@@ -9,7 +9,7 @@ Feature: As a restaurant owner
     And "Anna" is logged in as restaurant owner
     And "Anna" has a restaurant
     And the following dishes exist
-      | dish_name | dish_desc       | dish_price |
+      | name | description       | price |
       | Kebab     | Delicious kebab | 9000       |
 
   Scenario: Navigating to edit page
@@ -50,4 +50,4 @@ Feature: As a restaurant owner
     And I click the link "Edit dish"
     And I fill in "Dish Name" with ""
     And I click the "Submit" button
-    Then I should see "Dish name can't be blank"
+    Then I should see "Name can't be blank"

--- a/features/edit_menu.feature
+++ b/features/edit_menu.feature
@@ -6,7 +6,7 @@ Background:
   Given I am logged in as a restaurant owner
   And I already have a restaurant
   And the following dishes exist
-    | dish_name | dish_desc       | dish_price |
+    | name | description       | price |
     | Pizza     | Delicious pizza | 7000       |
     | Salad     | Leafy           | 1500       |
     | Olives    | Salty           | 900        |

--- a/features/menu_page.feature
+++ b/features/menu_page.feature
@@ -6,7 +6,7 @@ Background:
   Given I am logged in as a restaurant owner
   And I already have a restaurant
   And the following dishes exist
-    | dish_name | dish_desc       | dish_price |
+    | name | description       | price |
     | Pizza     | Delicious pizza | 7000       |
     | Salad     | Leafy           | 1500       |
     | Olives    | Salty           | 900        |

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -44,12 +44,12 @@ When(/^I fill in "([^"]*)" with "([^"]*)"$/) do |element, text|
 end
 
 Given(/^I am on the "([^"]*)" page for "([^"]*)"$/) do |page, dish|
-  @dish = Dish.find_by(dish_name: dish)
+  @dish = Dish.find_by(name: dish)
   visit goto(page)
 end
 
 Then(/^I should be on the "([^"]*)" page for "([^"]*)"$/) do |page, dish|
-  @dish = Dish.find_by(dish_name: dish)
+  @dish = Dish.find_by(name: dish)
   expect(current_path).to eq goto(page)
 end
 

--- a/features/step_definitions/cart_steps.rb
+++ b/features/step_definitions/cart_steps.rb
@@ -7,7 +7,7 @@ end
 
 Given(/^there is one dish in my cart$/) do
   steps %q{Given the following dish exist
-    | dish_name | dish_desc       | dish_price |
+    | name | description       | price |
     | Pizza     | Delicious pizza | 70         |
     And I am on the dish page for "Pizza"
     Then I click the link "Add to cart"}
@@ -15,7 +15,7 @@ end
 
 Given(/^there are two dishes in my cart$/) do
   steps %q{Given the following dish exist
-    | dish_name | dish_desc       | dish_price |
+    | name | description       | price |
     | Pizza     | Delicious pizza | 7000       |
     | Salad     | Leaves & stuff  | 1500       |
     And I am on the dish page for "Pizza"

--- a/features/step_definitions/dish_steps.rb
+++ b/features/step_definitions/dish_steps.rb
@@ -1,48 +1,48 @@
 Then(/^I should be on the dish page for "([^"]*)"$/) do |name|
-  dish = Dish.find_by(dish_name: name)
+  dish = Dish.find_by(name: name)
   expect(current_path).to eq dish_path(dish)
 end
 
 Given(/^I have the following dishes:$/) do |table|
   restaurant = Restaurant.first
   table.hashes.each do |dish|
-    FactoryGirl.create(:dish, dish_name: dish[:name], restaurant: restaurant)
+    FactoryGirl.create(:dish, name: dish[:name], restaurant: restaurant)
   end
 end
 
 Given(/^"([^"]*)" has a dish "([^"]*)"$/) do |name, dish_name|
   restaurant = User.find_by(name: name).restaurant
-  FactoryGirl.create(:dish, dish_name: dish_name, restaurant: restaurant)
+  FactoryGirl.create(:dish, name: dish_name, restaurant: restaurant)
 end
 
 Given(/^I am on the dish page for "([^"]*)"$/) do |dish|
-  dish_id = Dish.find_by(dish_name: dish)
+  dish_id = Dish.find_by(name: dish)
   visit dish_path(dish_id)
 end
 
 Given(/^"([^"]*)" has the following dishes:$/) do |name, table|
   owner = User.owners.find_by(name: name)
   table.hashes.each do |menu|
-    FactoryGirl.create(:dish, dish_name: dish[:name], restaurant: owner.restaurant)
+    FactoryGirl.create(:dish, name: dish[:name], restaurant: owner.restaurant)
   end
 end
 
 Given(/^I am on the edit dish page for "([^"]*)"$/) do |dish|
-  dish_id = Dish.find_by(dish_name: dish)
+  dish_id = Dish.find_by(name: dish)
   visit edit_dish_path(dish_id)
 end
 
 Given(/^the following dishes exists$/) do |table|
   table.hashes.each do |hash|
     user = User.find_by(name: hash[:owner])
-    FactoryGirl.create(:dish, dish_name: hash[:dish_name],
-                       dish_desc: hash[:dish_desc],
-                       dish_price: hash[:dish_price],
+    FactoryGirl.create(:dish, name: hash[:name],
+                       description: hash[:description],
+                       price: hash[:price],
                        user: user)
   end
 end
 
 Then(/^I should be on the edit dish page for "([^"]*)"$/) do |name|
-  dish = Dish.find_by(dish_name: name)
+  dish = Dish.find_by(name: name)
   expect(current_path).to eq edit_dish_path(dish)
 end

--- a/spec/factories/dishes.rb
+++ b/spec/factories/dishes.rb
@@ -1,11 +1,11 @@
 FactoryGirl.define do
   factory :dish do
-    dish_name 'MyString'
-    dish_desc 'MyText'
-    dish_price 1
-    dish_allergy 'MyText'
-    dish_cal 1
-    dish_ingredients 'MyText'
+    name 'MyString'
+    description 'MyText'
+    price 1
+    allergies 'MyText'
+    calories 1
+    ingredients 'MyText'
     restaurant {association(:restaurant)}
   end
 end

--- a/spec/models/dish_spec.rb
+++ b/spec/models/dish_spec.rb
@@ -2,21 +2,21 @@ require 'rails_helper'
 
 RSpec.describe Dish, type: :model do
   describe 'DB table' do
-    it { is_expected.to have_db_column :dish_name }
-    it { is_expected.to have_db_column :dish_desc }
-    it { is_expected.to have_db_column :dish_price }
-    it { is_expected.to have_db_column :dish_allergy }
-    it { is_expected.to have_db_column :dish_cal }
-    it { is_expected.to have_db_column :dish_ingredients }
+    it { is_expected.to have_db_column :name }
+    it { is_expected.to have_db_column :description }
+    it { is_expected.to have_db_column :price }
+    it { is_expected.to have_db_column :allergies }
+    it { is_expected.to have_db_column :calories }
+    it { is_expected.to have_db_column :ingredients }
 
     it { is_expected.to have_and_belong_to_many :menus }
     it { is_expected.to belong_to :restaurant }
   end
 
   describe 'Validations' do
-    it { is_expected.to validate_presence_of :dish_name }
-    it { is_expected.to validate_presence_of :dish_desc }
-    it { is_expected.to validate_presence_of :dish_price }
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_presence_of :description }
+    it { is_expected.to validate_presence_of :price }
     it { is_expected.to validate_presence_of :restaurant }
   end
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/131796241

Changes proposed in this pull request:
- Rename dish columns to take out the `dish_` bits
- Fix all the failing tests following that change

What I have learned working on this feature:
- Find/replace needs to be done a little more carefully, considering migrations, etc.

Ready for review!
