### PR TITLE
Removes whitespace above flash messages

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,4 +1,9 @@
-.navbar, .alert {
+.navbar {
+  margin-bottom: 0px;
+}
+.alert {
+  border-radius: 0px;
+  z-index:999;
   margin-bottom: 0px;
 }
 .h1-top {
@@ -58,7 +63,7 @@ h1 {
   width: 100%;
   height: 100%;
   padding: 0px;
-  margin: -22px 0px 0px 0px;
+  margin: 0px 0px 0px 0px;
   z-index: 1;
 }
 
@@ -165,8 +170,9 @@ p.desc-text{
 
 @media (max-width: 600px) {
   .question-container {
-    margin-top: 5px;
+    margin-top: 0px;
     width: 100%;
+    padding:10px;
   }
   .question-row {
     z-index: 0;


### PR DESCRIPTION
PT Story:
https://www.pivotaltracker.com/story/show/131923991

Changes proposed in this pull request:
- css changes to display flash error messages without whitespace above

What I have learned working on this feature: 
- KISS

Screenshots: 
<img width="332" alt="skarmavbild 2016-10-08 kl 00 13 36" src="https://cloud.githubusercontent.com/assets/7266909/19206883/5f81d984-8cec-11e6-95b6-ac5486b13b9d.png">
<img width="326" alt="skarmavbild 2016-10-08 kl 00 14 49" src="https://cloud.githubusercontent.com/assets/7266909/19206884/5f87319a-8cec-11e6-87e8-5157568c0af2.png">

Ready for review!
