### PR TITLE
Add infoWindow with link to restaurant on landing map

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -15,33 +15,27 @@ $(document).ready(function () {
     performGeolocation();
 });
 function addMarkers() {
-  if(selection == ('All Restaurants') ){
+  if(selection == ('All Restaurants')){
     map.removeMarkers();
     gon.all_restaurants.forEach(function (restaurant) {
-      if(restaurant.latitude !== null) {
-        map.addMarker({
-            lat: restaurant.latitude,
-            lng: restaurant.longitude,
-            infoWindow: {
-                content: "<a href='/restaurants/" + restaurant.id + "'>" + restaurant.name + "</a>"
-            }
-          });
-        }
-      }
-    );
+      placeMarkers(restaurant);
+    });
   } else {
     map.removeMarkers();
         gon.all_restaurants.forEach(function (restaurant) {
-          if(restaurant.latitude !== null) {
           if(restaurant.category == selection){
-            map.addMarker({
-                lat: restaurant.latitude,
-                lng: restaurant.longitude,
-                infoWindow: {
-                    content: "<a href='/restaurants/" + restaurant.id + "'>" + restaurant.name + "</a>"
-                }
-            });
+            placeMarkers(restaurant);
           }
+        });
+    }
+}
+function placeMarkers(restaurant) {
+  if(restaurant.latitude !== null) {
+    map.addMarker({
+        lat: restaurant.latitude,
+        lng: restaurant.longitude,
+        infoWindow: {
+            content: "<a href='/restaurants/" + restaurant.id + "'>" + restaurant.name + "</a>"
         }
       });
     }

--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -15,28 +15,35 @@ $(document).ready(function () {
     performGeolocation();
 });
 function addMarkers() {
-  if(selection == ('All Restaurants' || undefined) ){
+  if(selection == ('All Restaurants') ){
     map.removeMarkers();
     gon.all_restaurants.forEach(function (restaurant) {
+      if(restaurant.latitude !== null) {
         map.addMarker({
             lat: restaurant.latitude,
-            lng: restaurant.longitude
-        });
+            lng: restaurant.longitude,
+            infoWindow: {
+                content: "<a href='/restaurants/" + restaurant.id + "'>" + restaurant.name + "</a>"
+            }
+          });
+        }
       }
     );
   } else {
     map.removeMarkers();
         gon.all_restaurants.forEach(function (restaurant) {
+          if(restaurant.latitude !== null) {
           if(restaurant.category == selection){
             map.addMarker({
                 lat: restaurant.latitude,
                 lng: restaurant.longitude,
                 infoWindow: {
-                    content: "<a href='/restaurants/'" + restaurant.id + ">" + restaurant.name + "</a>"
+                    content: "<a href='/restaurants/" + restaurant.id + "'>" + restaurant.name + "</a>"
                 }
             });
           }
-        });
+        }
+      });
     }
 }
 function performGeolocation() {

--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -30,7 +30,10 @@ function addMarkers() {
           if(restaurant.category == selection){
             map.addMarker({
                 lat: restaurant.latitude,
-                lng: restaurant.longitude
+                lng: restaurant.longitude,
+                infoWindow: {
+                    content: "<a href='/restaurants/'" + restaurant.id + ">" + restaurant.name + "</a>"
+                }
             });
           }
         });

--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -34,13 +34,14 @@ function placeMarkers(restaurant) {
     map.addMarker({
         lat: restaurant.latitude,
         lng: restaurant.longitude,
+        title: restaurant.name,
         infoWindow: {
             content: "<a href='/restaurants/" + restaurant.id + "'>" + restaurant.name + "</a>"
         }
       });
     }
 }
-function performGeolocation() {
+function performGeolocation(lat, lng) {
   var latitude;
   var longitude;
   var testing_env = $('#map').data().testEnv;
@@ -59,8 +60,8 @@ function performGeolocation() {
           }
       });
   } else {
-      latitude = 57.690123;
-      longitude = 11.950632;
+      latitude = lat || 57.690123;
+      longitude = lng || 11.950632;
       map.setCenter(latitude, longitude);
   }
 }

--- a/features/landing_map.feature
+++ b/features/landing_map.feature
@@ -31,3 +31,11 @@ Feature: As a Customer
   Scenario: Viewing restaurants on the map by category
     When I select "Pizza" from "category"
     Then I should see "2" markers
+
+  # Scenario: One bad restaurant geocoding doesn't ruin the whole display
+  #   Given the following restaurants exists
+  #   | name     | description | zipcode | owner  | category |
+  #   | McNoZip  | Nice food   | 0       | Emma   | Pizza    |
+  #   And I am on the "index" page
+  #   When I select "Vegan" from "category"
+  #   Then I should see "2" markers

--- a/features/landing_map.feature
+++ b/features/landing_map.feature
@@ -15,21 +15,26 @@ Feature: As a Customer
       | McF  | Nice food   | 41677   | Janne  | Pizza    |
       | Jam  | Jam  food   | 41509   | Henrik | Thai     |
     And I am on the "index" page
+    And my location is set to "57.7088700" lat and "11.9745600" lng
+    And the map has been loaded
+
 
   Scenario: Viewing my location on the map
-    Given my location is set to "57.7088700" lat and "11.9745600" lng
-    And the map has been loaded
     Then the center of the map should be approximately "57.7088700" lat and "11.9745600" lng
 
   Scenario: Viewing the restaurants on the map
-    Given my location is set to "57.7088700" lat and "11.9745600" lng
-    And the map has been loaded
-    When I select "All Restaurants" from "category"
-    And the map has been loaded
+    Given I select "All Restaurants" from "category"
     Then I should see "3" markers
 
   Scenario: Viewing restaurants on the map by category
-    When I select "Pizza" from "category"
+    Given I select "Pizza" from "category"
     Then I should see "2" markers
 
-  
+
+  Scenario: Clicking on marker displays info box
+    Given I select "Thai" from "category"
+    And the map has been loaded
+    And I click on the marker for "Jam"
+    Then I should see an info window for Jam
+    Then show me an image of the page
+

--- a/features/landing_map.feature
+++ b/features/landing_map.feature
@@ -19,7 +19,7 @@ Feature: As a Customer
   Scenario: Viewing my location on the map
     Given my location is set to "57.7088700" lat and "11.9745600" lng
     And the map has been loaded
-    # How could we test for the map actually centering on the user?
+    Then the center of the map should be approximately "57.7088700" lat and "11.9745600" lng
 
   Scenario: Viewing the restaurants on the map
     Given my location is set to "57.7088700" lat and "11.9745600" lng
@@ -30,4 +30,8 @@ Feature: As a Customer
 
   Scenario: Viewing restaurants on the map by category
     When I select "Pizza" from "category"
+    Then I should see "2" markers
+
+  Scenario: Viewing restaurants on the map by category
+    When I select "Thai" from "category"
     Then I should see "2" markers

--- a/features/landing_map.feature
+++ b/features/landing_map.feature
@@ -35,6 +35,5 @@ Feature: As a Customer
     Given I select "Thai" from "category"
     And the map has been loaded
     And I click on the marker for "Jam"
-    Then I should see an info window for Jam
-    Then show me an image of the page
+    Then I should see an info window for "Jam"
 

--- a/features/landing_map.feature
+++ b/features/landing_map.feature
@@ -31,11 +31,3 @@ Feature: As a Customer
   Scenario: Viewing restaurants on the map by category
     When I select "Pizza" from "category"
     Then I should see "2" markers
-
-  # Scenario: One bad restaurant geocoding doesn't ruin the whole display
-  #   Given the following restaurants exists
-  #   | name     | description | zipcode | owner  | category |
-  #   | McNoZip  | Nice food   | 0       | Emma   | Pizza    |
-  #   And I am on the "index" page
-  #   When I select "Vegan" from "category"
-  #   Then I should see "2" markers

--- a/features/landing_map.feature
+++ b/features/landing_map.feature
@@ -32,6 +32,4 @@ Feature: As a Customer
     When I select "Pizza" from "category"
     Then I should see "2" markers
 
-  Scenario: Viewing restaurants on the map by category
-    When I select "Thai" from "category"
-    Then I should see "2" markers
+  

--- a/features/step_definitions/map_steps.rb
+++ b/features/step_definitions/map_steps.rb
@@ -39,24 +39,26 @@ end
 
 
 Then(/^the center of the map should be approximately "([^"]*)" lat and "([^"]*)" lng$/) do |lat, lng|
-  accepted_offset = 0.2
+  ACCEPTED_OFFSET = 0.2
   center_lat = page.evaluate_script('map.getCenter().lat();')
   center_lng = page.evaluate_script('map.getCenter().lng();')
-  expect(center_lat).to be_within(accepted_offset).of(lat.to_f)
-  expect(center_lng).to be_within(accepted_offset).of(lng.to_f)
+  expect(center_lat).to be_within(ACCEPTED_OFFSET).of(lat.to_f)
+  expect(center_lng).to be_within(ACCEPTED_OFFSET).of(lng.to_f)
 end
 
 And(/^I click on the marker for "([^"]*)"$/) do |title|
-  page.execute_script(" var m = map.markers.find(function(marker){
-                                   return marker.title == '#{title}'
-                                });
-                       google.maps.event.trigger(m, 'click');
-                      ")
-  # it works in console but this script is causing errors the we activate js_errors for Poltergeist
+  script = "map.markers.forEach(function(marker){
+                if (marker.title == '#{title}'){
+                    google.maps.event.trigger(marker, 'click')
+                }
+            });"
+  page.execute_script(script)
 end
 
-Then(/^I should see an info window for Jam$/) do
-  sleep(2)
-  #Here we want to get the marker again and make sure that
-  # marker.infoWindow.anchor.visible == true
+Then(/^I should see an info window for "([^"]*)"/) do |name|
+  restaurant = Restaurant.find_by(name: name)
+  within '#map' do
+    expect(page).to have_selector '.gm-style-iw', count: 1
+    expect(page).to have_link restaurant.name
+  end
 end

--- a/features/step_definitions/map_steps.rb
+++ b/features/step_definitions/map_steps.rb
@@ -19,17 +19,15 @@ Given(/^my location is set to "([^"]*)" lat and "([^"]*)" lng$/) do |lat, lng|
   simulate_location(latitude, longitude)
 end
 
-When(/^(?:I expect a Google map to load|the map has been loaded)$/)do
+When(/^(?:I expect a Google map to load|the map has been loaded)$/) do
   sleep(1)
   expect(page).to have_css '#map .gm-style'
 end
 
 
 def simulate_location(lat, lng)
-  page.execute_script("GMaps.geolocate({
-                        success: function (position) {
-                        map.setCenter(#{lat}, #{lng})}
-                        });")
+  page.execute_script("performGeolocation(#{lat}, #{lng})")
+  sleep(1)
 end
 
 
@@ -46,4 +44,19 @@ Then(/^the center of the map should be approximately "([^"]*)" lat and "([^"]*)"
   center_lng = page.evaluate_script('map.getCenter().lng();')
   expect(center_lat).to be_within(accepted_offset).of(lat.to_f)
   expect(center_lng).to be_within(accepted_offset).of(lng.to_f)
+end
+
+And(/^I click on the marker for "([^"]*)"$/) do |title|
+  page.execute_script(" var m = map.markers.find(function(marker){
+                                   return marker.title == '#{title}'
+                                });
+                       google.maps.event.trigger(m, 'click');
+                      ")
+  # it works in console but this script is causing errors the we activate js_errors for Poltergeist
+end
+
+Then(/^I should see an info window for Jam$/) do
+  sleep(2)
+  #Here we want to get the marker again and make sure that
+  # marker.infoWindow.anchor.visible == true
 end

--- a/features/step_definitions/map_steps.rb
+++ b/features/step_definitions/map_steps.rb
@@ -35,6 +35,15 @@ end
 
 Then(/^I should see "([^"]*)" (?:marker|markers)$/) do |count|
   sleep(1)
-  expected_count = page.evaluate_script('map.markers.length')
+  expected_count = page.evaluate_script('map.markers.length;')
   expect(expected_count).to eq count.to_i
+end
+
+
+Then(/^the center of the map should be approximately "([^"]*)" lat and "([^"]*)" lng$/) do |lat, lng|
+  accepted_offset = 0.2
+  center_lat = page.evaluate_script('map.getCenter().lat();')
+  center_lng = page.evaluate_script('map.getCenter().lng();')
+  expect(center_lat).to be_within(accepted_offset).of(lat.to_f)
+  expect(center_lng).to be_within(accepted_offset).of(lng.to_f)
 end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/131907967

Changes proposed in this pull request:
- Add pop-up info window to google map markers
- Include link to restaurant in the info window
- DRY up maps.js marker function
- Prevent restaurants with no lat/lon from screwing up the whole output.

I'm pretty satisfied with where this is now, but @tochman requested the marker be centered on the map when a marker is clicked. That's similar to what I failed to accomplish earlier in terms of listening for the selection to change, so I'm just going to leave it here. (Would love to learn how to do this when someone has time to show me - a couple of other features rely on similar methods.)

What I have learned working on this feature: 
- How to debug more effectively in the browser
- More tips for acceptance testing Javascript things

Screenshots: 
![screen shot 2016-10-08 at 3 31 25 pm](https://cloud.githubusercontent.com/assets/20141428/19213413/516eb5e4-8d6c-11e6-82be-a2e4b5bc9032.png)

Ready for review!
