### PR TITLE
Fix bug: navbar 'show your restaurant' should take you to your actual restaurant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ vendor/bundle/
 
 #ignore the env file
 .env
+
+#ignore image uploads
+public/system/*

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,6 @@ class User < ApplicationRecord
   end
 
   def has_restaurant?
-    self.restaurant != nil
+    self.restaurant != nil && self.restaurant.id != nil
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,4 +24,8 @@ class User < ApplicationRecord
   def customer?
     self.role == 'customer'
   end
+
+  def has_restaurant?
+    self.restaurant != nil
+  end
 end

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -20,27 +20,28 @@
               Restaurant
               %strong.caret
             %ul.dropdown-menu
-              - unless current_user.restaurant.nil?
+              - unless current_user.restaurant.nil? || current_user.restaurant.id.nil?
                 %li
                   = link_to 'Show your restaurant', restaurant_path(current_user.restaurant)
+                %li
+                  = link_to 'Update your restaurant', edit_restaurant_path(current_user.restaurant)
               %li
-                = link_to 'Create a new restaurant', new_restaurant_path(current_user)
-              %li
-                = link_to 'Update your restaurant', edit_restaurant_path(current_user)
+                = link_to 'Create a new restaurant', new_restaurant_path
+
             %li.dropdown
               = link_to '#', {class: 'dropdown-toggle', data: {toggle: 'dropdown'}} do
                 Menu
                 %strong.caret
               %ul.dropdown-menu
                 %li
-                  = link_to 'Create a menu', new_menu_path(current_user.restaurant)
+                  = link_to 'Create a menu', new_menu_path
             %li.dropdown
               = link_to '#', {class: 'dropdown-toggle', data: {toggle: 'dropdown'}} do
                 Dishes
                 %strong.caret
               %ul.dropdown-menu
                 %li
-                  = link_to 'Create a dish', new_dish_path(current_user.restaurant)
+                  = link_to 'Create a dish', new_dish_path
         - if can? :create, ShoppingCart
           %li
             = link_to 'Show cart', carts_path

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -20,7 +20,7 @@
               Restaurant
               %strong.caret
             %ul.dropdown-menu
-              - unless current_user.restaurant.nil? || current_user.restaurant.id.nil?
+              - if current_user.has_restaurant?
                 %li
                   = link_to 'Show your restaurant', restaurant_path(current_user.restaurant)
                 %li

--- a/app/views/application/_navbar.html.haml
+++ b/app/views/application/_navbar.html.haml
@@ -20,8 +20,9 @@
               Restaurant
               %strong.caret
             %ul.dropdown-menu
-              %li
-                = link_to 'Show your restaurant', restaurant_path(current_user)
+              - unless current_user.restaurant.nil?
+                %li
+                  = link_to 'Show your restaurant', restaurant_path(current_user.restaurant)
               %li
                 = link_to 'Create a new restaurant', new_restaurant_path(current_user)
               %li

--- a/features/navbar.feature
+++ b/features/navbar.feature
@@ -39,5 +39,11 @@ Scenario: Links to see as a restaurant owner
     | content                 |
     | Home                    |
     | Create a new restaurant |
-    | Show your restaurant    |
   And I should not see "Show cart"
+  And I should not see "Show your restaurant"
+
+Scenario: Links to see as a restaurant owner with a restaurant
+  Given I am logged in as a restaurant owner
+  And I already have a restaurant
+  And I am on the "index" page
+  Then I should see "Show your restaurant"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe User, type: :model do
       expect(subject.role).to eq 'customer'
     end
 
-
     it 'can set the role to restaurant owner' do
       owner = create(:user, role: 'owner')
       expect(owner).to be_valid
@@ -66,6 +65,18 @@ RSpec.describe User, type: :model do
     it '#owners' do
       expect(User.owners).to include owner
       expect(User.owners).not_to include customer
+    end
+  end
+
+  describe 'Owner methods' do
+    let(:owner) { create(:user, email: 'whatever@random_restaurant.com', role: 'owner') }
+    let(:restaurant) { create(:restaurant, user: User.first) }
+
+    it 'has a restaurant' do
+      owner.name = "Fred"
+      restaurant.name = "Fred's Restaurant"
+      # I know this is stupid, but the user and restaurant weren't showing up in this 'it' block!
+      expect(owner.has_restaurant?).to eq true
     end
 
   end


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/131954255

Changes proposed in this pull request:
- Add scenario for testing `Show your restaurant` only if owner already has a restaurant
- Direct owner to his own restaurant from `Show your restaurant` link (vs. his user number)

I think what happened is in test, the owner is always the first owner and the restaurant is always the first restaurant, so you don't catch this bug until you get to the "wild".

Ready for review!
