### PR TITLE
When a user deletes his account, all records associated with that user should also be deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ vendor/bundle/
 
 #ignore the env file
 .env
+
+#ignore image uploads
+public/system/*

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -3,8 +3,8 @@ class Restaurant < ApplicationRecord
   PERMITTED_CATEGORIES = %w(Other Pizza Sushi Italian Thai Fast\ Food BBQ French Traditional Vegan Seafood TexMex)
 
   belongs_to :user
-  has_many :menus
-  has_many :dishes
+  has_many :menus, dependent: :destroy
+  has_many :dishes, dependent: :destroy
   geocoded_by :full_address
   after_validation :geocode
   validates_presence_of :user, :name, :category, :street, :zipcode, :town
@@ -16,4 +16,3 @@ class Restaurant < ApplicationRecord
     [street, zipcode, town].join(', ')
   end
 end
-

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
-  has_one :restaurant
-  has_many :shopping_carts
+  has_one :restaurant, dependent: :destroy
+  has_many :shopping_carts, dependent: :destroy
 
   PERMITTED_ROLES = %w(customer owner)
 

--- a/features/restaurant_owner.feature
+++ b/features/restaurant_owner.feature
@@ -16,3 +16,10 @@ Feature: As a restaurant Owner
       | Password confirmation | password                                        |
     When I click the "Register" button
     Then there should be "1" restaurant owner in the system
+
+  Scenario: I cancel my account
+    Given I am logged in as a restaurant owner
+    When I am on the "edit profile" page
+    And I click the "Cancel my account" button
+    Then I should be on the "index" page
+    And I should see "Bye! Your account has been successfully cancelled"

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -90,6 +90,8 @@ def goto(page)
     user_registration_path
   when 'create restaurant'
     new_restaurant_path
+  when 'edit profile'
+    edit_user_registration_path
   else
     root_path
   end

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Restaurant, type: :model do
     it { is_expected.to have_db_column :latitude}
     it { is_expected.to have_db_column :longitude}
     it { is_expected.to belong_to :user }
-    it { is_expected.to have_many :menus }
-    it { is_expected.to have_many :dishes }
+    it { is_expected.to have_many(:menus).dependent(:destroy) }
+    it { is_expected.to have_many(:dishes).dependent(:destroy) }
     it {is_expected.to validate_presence_of :user}
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe User, type: :model do
   end
 
   describe 'associations' do
-    it { is_expected.to have_many :shopping_carts }
-    it { is_expected.to have_one :restaurant }
+    it { is_expected.to have_many(:shopping_carts).dependent(:destroy) }
+    it { is_expected.to have_one(:restaurant).dependent(:destroy) }
   end
 
   describe 'Factory' do


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/131954795

Changes proposed in this pull request:
- Create `dependent: destroy` association between users and shopping carts and users and restaurants
- Create `dependent: destroy` association between restaurants and menus and dishes

What I have learned working on this feature: Refresh on how to test this

Ready for review!
