### PR TITLE
Hide "Add dishes" on Menu create/edit page if no dishes exist

### DIFF
--- a/app/views/menus/_form.html.haml
+++ b/app/views/menus/_form.html.haml
@@ -1,0 +1,13 @@
+= form_for @menu, class: 'form-group' do |f|
+  = f.label :title do
+    = f.text_field :title, id: 'title', class: 'form-control'
+  %p#dishes
+    - unless current_user.restaurant.dishes.empty?
+      %h3 Check to add dishes to menu:
+      = f.collection_check_boxes :dish_ids, @dishes, :id, :name do |b|
+        .checkbox
+          = b.check_box + b.label
+  - if current_page?(new_menu_path)
+    = f.submit 'Create', id: 'create', class: 'btn btn-warning'
+  - else
+    = f.submit 'Update', id: 'update', class: 'btn btn-warning'

--- a/app/views/menus/edit.html.haml
+++ b/app/views/menus/edit.html.haml
@@ -3,12 +3,4 @@
 .container
   .row
     .col-md-8.col-xs-12
-      = form_for @menu, action: :update, class: 'form-group'  do |f|
-        = f.label :title, 'Edit Title'
-        = f.text_field :title, id: 'title', class: 'form-control'
-        - if !@menu.dishes.nil?
-          %h3 Check to add dishes to menu:
-          = f.collection_check_boxes :dish_ids, @dishes, :id, :name do |b|
-            .checkbox
-              = b.check_box + b.label
-        = f.submit 'Update', id: 'create', class: 'btn btn-warning'
+      = render partial: 'form'

--- a/app/views/menus/new.html.haml
+++ b/app/views/menus/new.html.haml
@@ -7,8 +7,8 @@
         = f.label :title do
           = f.text_field :title, id: 'title', class: 'form-control'
         %p#dishes
-          - unless @dishes.nil?
-            %h3 Add Dishes
+          - unless current_user.restaurant.dishes.empty?
+            %h3 Check to add dishes to menu:
             = f.collection_check_boxes :dish_ids, @dishes, :id, :name do |b|
               .checkbox
                 = b.check_box + b.label

--- a/app/views/menus/new.html.haml
+++ b/app/views/menus/new.html.haml
@@ -3,13 +3,4 @@
 .container
   .row
     .col-md-8.col-xs-12
-      = form_for @menu, class: 'form-group' do |f|
-        = f.label :title do
-          = f.text_field :title, id: 'title', class: 'form-control'
-        %p#dishes
-          - unless current_user.restaurant.dishes.empty?
-            %h3 Check to add dishes to menu:
-            = f.collection_check_boxes :dish_ids, @dishes, :id, :name do |b|
-              .checkbox
-                = b.check_box + b.label
-        = f.submit 'Create', id: 'create', class: 'btn btn-warning'
+      = render partial: 'form'

--- a/features/add_menu.feature
+++ b/features/add_menu.feature
@@ -48,3 +48,7 @@ Feature: As a restaurant Owner
     When I am on the "add menu" page
     Then I should be on the "index" page
     And I should see "You are not authorized to access this page"
+
+  Scenario: Adding a menu with no dishes created
+    Given I am on the "add menu" page
+    Then I should not see "add dishes"


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/131879613

Changes proposed in this pull request:
- Hide "add dishes" headline if there are no dishes to add to menu

What I have learned working on this feature: How to check the current path on a page

Ready for review!
